### PR TITLE
Add the ability to pass a custom environment to the pipeline

### DIFF
--- a/pipe/pipeline.go
+++ b/pipe/pipeline.go
@@ -35,8 +35,7 @@ var FinishEarly = errors.New("finish stage early")
 type AppendVars func(context.Context, []EnvVar) []EnvVar
 
 // EnvVar represents an environment variable that will be provided to any child
-// process spawned in this pipeline. Only one of ValueFunc or Value should be
-// provided.
+// process spawned in this pipeline.
 type EnvVar struct {
 	// The name of the environment variable.
 	Key string


### PR DESCRIPTION
This functionality was only available in gitrpcd, but it could be useful for anyone using this library


