### PR TITLE
Move the new memory limit functionality

### DIFF
--- a/internal/ptree/ptree.go
+++ b/internal/ptree/ptree.go
@@ -1,0 +1,127 @@
+//go:build linux
+
+// Package ptree contains utilities for dealing with Linux process trees.
+package ptree
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var (
+	errNoRss  = errors.New("RssAnon was not found")
+	procfs    = os.DirFS("/proc")
+	rssAnonRE = regexp.MustCompile(`^RssAnon:\s*(\d+)\s+kB($|\s)`)
+)
+
+// Return the RSSAnon of a single process `pid`.
+func GetProcessRSSAnon(pid int) (uint64, error) {
+	status := fmt.Sprintf("%d/status", pid)
+	f, err := procfs.Open(status)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+
+	scan := bufio.NewScanner(f)
+	for scan.Scan() {
+		line := scan.Text()
+		if rss, ok := ParseRSSAnon(line); ok {
+			return rss, nil
+		}
+	}
+	if scan.Err() != nil {
+		return 0, scan.Err()
+	}
+	return 0, errNoRss
+}
+
+// Return the total RSS of the tree of processes rooted at `pid`.
+//
+// If the passed root pid is that of a kernel thread, as a special case, we
+// return zero and no error.
+//
+// Errors encountered while walking the children are ignored, since it can
+// change while traversing it.
+func GetProcessTreeRSSAnon(pid int) (uint64, error) {
+	total, err := GetProcessRSSAnon(pid)
+	if err != nil {
+		if err == errNoRss {
+			// these are typically kernel threads, which don't have an address space to measure
+			return 0, nil
+		}
+		return 0, err
+	}
+
+	WalkChildren(pid, func(pid int) {
+		mem, err := GetProcessRSSAnon(pid)
+		if err != nil {
+			return
+		}
+		total += mem
+	})
+
+	return total, nil
+}
+
+// Walk the child processes of the specified root process. walkFn will be called
+// for each child found. It will not be called for the root process. Any errors
+// will be ignored, since they may be just a consequence of the process tree
+// changing during traversal.
+func WalkChildren(pid int, walkFn func(int)) {
+	walkChildPids(pid, walkFn, map[int]bool{pid: true})
+}
+
+func walkChildPids(pid int, walkFn func(int), visited map[int]bool) {
+	matches, err := fs.Glob(procfs, fmt.Sprintf("%d/task/*/children", pid))
+	if err != nil {
+		return
+	}
+
+	for _, filename := range matches {
+		walkChildrenFile(filename, walkFn, visited)
+	}
+}
+
+func walkChildrenFile(filename string, walkFn func(int), visited map[int]bool) {
+	data, err := fs.ReadFile(procfs, filename)
+	if err != nil {
+		return
+	}
+
+	for _, pidStr := range strings.Fields(string(data)) {
+		pid, err := strconv.Atoi(pidStr)
+		if err != nil {
+			continue
+		}
+		if visited[pid] {
+			continue
+		}
+
+		walkFn(pid)
+		visited[pid] = true
+		walkChildPids(pid, walkFn, visited)
+	}
+}
+
+// parseRSSAnon parses an "RssAnon" line from /proc/*/status and returns the size.
+// The entire line should be passed in, with or without the line ending. If the
+// line looks like "RssAnon: 1234 kB", the byte size will be returned. If the
+// line isn't parseable, (0, false) will be returned.
+func ParseRSSAnon(s string) (uint64, bool) {
+	m := rssAnonRE.FindStringSubmatch(s)
+	if m == nil {
+		return 0, false
+	}
+	kb, err := strconv.ParseUint(m[1], 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return kb * 1024, true
+}

--- a/internal/ptree/ptree_test.go
+++ b/internal/ptree/ptree_test.go
@@ -1,0 +1,172 @@
+package ptree_test
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/github/go-pipe/internal/ptree"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TODO: use mocks, not the actual process tree
+func TestGetProcessTreeRSS(t *testing.T) {
+	mem := map[int]uint64{}
+	treeMem := map[int]uint64{}
+
+	pids := allPids(t)
+	for _, pid := range pids {
+		rss, err := ptree.GetProcessRSSAnon(pid)
+		if err == nil {
+			mem[pid] = rss
+		}
+		rss, err = ptree.GetProcessTreeRSSAnon(pid)
+		if err == nil {
+			treeMem[pid] = rss
+		}
+	}
+
+	var less, equal, greater int
+	for pid, treeRss := range treeMem {
+		if rss, ok := mem[pid]; ok {
+			switch {
+			case treeRss > rss:
+				greater++
+			case treeRss == rss:
+				equal++
+			default:
+				less++
+			}
+		}
+	}
+	require.Positive(t, greater) // detect process trees using more mem than their root process
+	require.Positive(t, equal)   // process trees with no children have the same mem usage as root
+
+	// We should *extremely* rarely find a tree using less memory than its root
+	// process. However, this is a little racy since any process in the tree can
+	// return memory to the OS between our measurements. Allow this to happen
+	// once at most just to reduce the risk of flakiness.
+	require.LessOrEqual(t, less, 1)
+}
+
+func TestWalkChildren(t *testing.T) {
+	const depth = 5
+
+	arg := "echo ready; read -r x;"
+	for i := 0; i < depth; i++ {
+		arg = fmt.Sprintf("sh -c %q", arg)
+	}
+
+	cmd := exec.Command("sh", "-c", arg)
+	stdin, err := cmd.StdinPipe()
+	require.NoError(t, err)
+	stdout, err := cmd.StdoutPipe()
+	require.NoError(t, err)
+	require.NoError(t, cmd.Start())
+
+	// Wait for the process to start by reading the expected output from the
+	// innermost child.
+	var ready [5]byte
+	_, err = stdout.Read(ready[:])
+	require.NoError(t, err, "process didn't appear to start successfully")
+	require.Equal(t, "ready", string(ready[:]))
+
+	var numChildren int
+	ptree.WalkChildren(cmd.Process.Pid, func(pid int) {
+		numChildren++
+	})
+	assert.Equal(t, depth, numChildren)
+
+	// Gracefully exit the process tree.
+	_, err = stdin.Write([]byte("\n"))
+	require.NoError(t, err)
+	require.NoError(t, stdin.Close())
+	require.NoError(t, cmd.Wait())
+}
+
+func TestParseRss(t *testing.T) {
+	const kb = 1024
+
+	okExamples := []struct {
+		input  string
+		result uint64
+	}{
+		{
+			input:  "RssAnon:\t   15032 kB",
+			result: 15032 * kb,
+		},
+		{
+			input:  "RssAnon:\t   15032 kB\n",
+			result: 15032 * kb,
+		},
+		{
+			input:  "RssAnon:\t99915032 kB",
+			result: 99915032 * kb,
+		},
+		{
+			input:  "RssAnon:\t       1 kB",
+			result: kb,
+		},
+	}
+
+	for _, example := range okExamples {
+		rss, ok := ptree.ParseRSSAnon(example.input)
+		if assert.Truef(t, ok, "should be able to parse %q", example.input) {
+			assert.Equalf(t, example.result, rss, "value of %q", example.input)
+		}
+	}
+
+	badExamples := []string{
+		"",
+		"\n",
+		"RssAnon:\t 123",
+		"RssAnonn:\t 123 kB",
+		"RssAno:\t 123 kB",
+		"Blah:\t 123 kB",
+		"Blah:",
+		"123",
+	}
+
+	for _, example := range badExamples {
+		_, ok := ptree.ParseRSSAnon(example)
+		assert.Falsef(t, ok, "should not be able to parse %q", example)
+	}
+}
+
+func BenchmarkParseRss(b *testing.B) {
+	b.Run("match", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			rss, ok := ptree.ParseRSSAnon("RssAnon:\t   15032 kB")
+			require.True(b, ok)
+			require.EqualValues(b, 15032*1024, rss)
+		}
+	})
+
+	b.Run("no match", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, ok := ptree.ParseRSSAnon("Other:\t   15032 kB")
+			require.False(b, ok)
+		}
+	})
+}
+
+func allPids(t *testing.T) []int {
+	procfs := os.DirFS("/proc")
+	matches, err := fs.Glob(procfs, "[0-9]*[0-9]/task")
+	require.Nil(t, err)
+
+	var pids = make([]int, 0, len(matches))
+	for _, m := range matches {
+		ns := strings.SplitN(m, "/", 2)
+		pid, err := strconv.Atoi(ns[0])
+		require.Nil(t, err)
+		pids = append(pids, pid)
+	}
+	require.NotEmpty(t, pids)
+	return pids
+}

--- a/pipe/command_linux.go
+++ b/pipe/command_linux.go
@@ -3,11 +3,10 @@
 package pipe
 
 import (
-	"bufio"
 	"context"
 	"errors"
-	"fmt"
-	"os"
+
+	"github.com/github/go-pipe/internal/ptree"
 )
 
 // On linux, we can limit or observe memory usage in command stages.
@@ -17,26 +16,10 @@ var (
 	errProcessInfoMissing = errors.New("cmd.Process is nil")
 )
 
-func (s *commandStage) GetRSS(ctx context.Context) (uint64, error) {
+func (s *commandStage) GetRSSAnon(ctx context.Context) (uint64, error) {
 	if s.cmd.Process == nil {
 		return 0, errProcessInfoMissing
 	}
 
-	f, err := os.Open(fmt.Sprintf("/proc/%d/status", s.cmd.Process.Pid))
-	if err != nil {
-		return 0, err
-	}
-	defer f.Close()
-
-	scan := bufio.NewScanner(f)
-	for scan.Scan() {
-		line := scan.Text()
-		if rss, ok := parseRSS(line); ok {
-			return rss, nil
-		}
-	}
-	if scan.Err() != nil {
-		return 0, scan.Err()
-	}
-	return 0, errors.New("RssAnon was not found in /proc/[pid]/status")
+	return ptree.GetProcessTreeRSSAnon(s.cmd.Process.Pid)
 }

--- a/pipe/memorylimit.go
+++ b/pipe/memorylimit.go
@@ -3,7 +3,9 @@ package pipe
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
+	"sync"
 	"time"
 )
 
@@ -14,30 +16,36 @@ const memoryPollInterval = time.Second
 var ErrMemoryLimitExceeded = errors.New("memory limit exceeded")
 
 // LimitableStage is the superset of Stage that must be implemented by stages
-// passed to MemoryLimit and MemoryObsever.
+// passed to MemoryLimit and MemoryObserver.
 type LimitableStage interface {
 	Stage
 
-	GetRSS(context.Context) (uint64, error)
+	GetRSSAnon(context.Context) (uint64, error)
 	Kill(error)
 }
 
 // MemoryLimit watches the memory usage of the stage and stops it if it
 // exceeds the given limit.
-func MemoryLimit(stage Stage, byteLimit uint64) Stage {
+func MemoryLimit(stage Stage, byteLimit uint64, eventHandler func(e *Event)) Stage {
+
 	limitableStage, ok := stage.(LimitableStage)
 	if !ok {
+		eventHandler(&Event{
+			Command: stage.Name(),
+			Msg:     "invalid pipe.MemoryLimit usage",
+			Err:     fmt.Errorf("invalid pipe.MemoryLimit usage"),
+		})
 		return stage
 	}
 
 	return &memoryWatchStage{
 		nameSuffix: " with memory limit",
 		stage:      limitableStage,
-		watch:      killAtLimit(byteLimit),
+		watch:      killAtLimit(byteLimit, eventHandler),
 	}
 }
 
-func killAtLimit(byteLimit uint64) memoryWatchFunc {
+func killAtLimit(byteLimit uint64, eventHandler func(e *Event)) memoryWatchFunc {
 	return func(ctx context.Context, stage LimitableStage) {
 		var consecutiveErrors int
 
@@ -49,15 +57,31 @@ func killAtLimit(byteLimit uint64) memoryWatchFunc {
 			case <-ctx.Done():
 				return
 			case <-t.C:
-				rss, err := stage.GetRSS(ctx)
+				rss, err := stage.GetRSSAnon(ctx)
 				if err != nil {
 					consecutiveErrors++
+					if consecutiveErrors >= 2 {
+						eventHandler(&Event{
+							Command: stage.Name(),
+							Msg:     "error getting RSS",
+							Err:     err,
+						})
+					}
 					continue
 				}
 				consecutiveErrors = 0
 				if rss < byteLimit {
 					continue
 				}
+				eventHandler(&Event{
+					Command: stage.Name(),
+					Msg:     "stage exceeded allowed memory use",
+					Err:     fmt.Errorf("stage exceeded allowed memory use"),
+					Context: map[string]interface{}{
+						"limit": byteLimit,
+						"used":  rss,
+					},
+				})
 				stage.Kill(ErrMemoryLimitExceeded)
 				return
 			}
@@ -67,19 +91,25 @@ func killAtLimit(byteLimit uint64) memoryWatchFunc {
 
 // MemoryObserver watches memory use of the stage and logs the maximum
 // value when the stage exits.
-func MemoryObserver(stage Stage) Stage {
+func MemoryObserver(stage Stage, eventHandler func(e *Event)) Stage {
 	limitableStage, ok := stage.(LimitableStage)
 	if !ok {
+		eventHandler(&Event{
+			Command: stage.Name(),
+			Msg:     "invalid pipe.MemoryObserver usage",
+			Err:     fmt.Errorf("invalid pipe.MemoryObserver usage"),
+		})
 		return stage
 	}
 
 	return &memoryWatchStage{
 		stage: limitableStage,
-		watch: logMaxRSS(),
+		watch: logMaxRSS(eventHandler),
 	}
 }
 
-func logMaxRSS() memoryWatchFunc {
+func logMaxRSS(eventHandler func(e *Event)) memoryWatchFunc {
+
 	return func(ctx context.Context, stage LimitableStage) {
 		var (
 			maxRSS                             uint64
@@ -92,12 +122,30 @@ func logMaxRSS() memoryWatchFunc {
 		for {
 			select {
 			case <-ctx.Done():
+				eventHandler(&Event{
+					Command: stage.Name(),
+					Msg:     "peak memory usage",
+					Context: map[string]interface{}{
+						"max_rss_bytes": maxRSS,
+						"samples":       samples,
+						"errors":        errors,
+					},
+				})
+
 				return
 			case <-t.C:
-				rss, err := stage.GetRSS(ctx)
+				rss, err := stage.GetRSSAnon(ctx)
 				if err != nil {
 					errors++
 					consecutiveErrors++
+					if consecutiveErrors == 2 {
+						eventHandler(&Event{
+							Command: stage.Name(),
+							Msg:     "error getting RSS",
+							Err:     err,
+						})
+					}
+					// don't log any more errors until we get rss successfully.
 					continue
 				}
 
@@ -115,6 +163,8 @@ type memoryWatchStage struct {
 	nameSuffix string
 	stage      LimitableStage
 	watch      memoryWatchFunc
+	cancel     context.CancelFunc
+	wg         sync.WaitGroup
 }
 
 type memoryWatchFunc func(context.Context, LimitableStage)
@@ -130,18 +180,37 @@ func (m *memoryWatchStage) Start(ctx context.Context, env Env, stdin io.ReadClos
 	if err != nil {
 		return nil, err
 	}
-	go m.watch(ctx, m.stage)
+
+	ctx, cancel := context.WithCancel(ctx)
+	m.cancel = cancel
+	m.wg.Add(1)
+
+	go func() {
+		m.watch(ctx, m.stage)
+		m.wg.Done()
+	}()
+
 	return io, nil
 }
 
 func (m *memoryWatchStage) Wait() error {
-	return m.stage.Wait()
+	if err := m.stage.Wait(); err != nil {
+		return err
+	}
+	m.stopWatching()
+	return nil
 }
 
-func (m *memoryWatchStage) GetRSS(ctx context.Context) (uint64, error) {
-	return m.stage.GetRSS(ctx)
+func (m *memoryWatchStage) GetRSSAnon(ctx context.Context) (uint64, error) {
+	return m.stage.GetRSSAnon(ctx)
 }
 
 func (m *memoryWatchStage) Kill(err error) {
 	m.stage.Kill(err)
+	m.stopWatching()
+}
+
+func (m *memoryWatchStage) stopWatching() {
+	m.cancel()
+	m.wg.Wait()
 }

--- a/pipe/memorylimit_test.go
+++ b/pipe/memorylimit_test.go
@@ -1,0 +1,166 @@
+package pipe_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/github/go-pipe/pipe"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func LogEventHandler(logger *log.Logger) func(*pipe.Event) {
+	return func(e *pipe.Event) {
+		ctx := ""
+		for k, v := range e.Context {
+			ctx = fmt.Sprintf("%s,%s=%v", ctx, k, v)
+		}
+
+		logger.Printf("Command %s failed with message %s and error %s. Context: %s", e.Command, e.Msg, e.Command, ctx)
+	}
+}
+
+func TestMemoryObserverSimple(t *testing.T) {
+	t.Parallel()
+	rss := testMemoryObserver(t, 400, pipe.Command("less"))
+	require.Greater(t, rss, 400_000_000)
+}
+
+func TestMemoryObserverTreeMem(t *testing.T) {
+	t.Parallel()
+
+	// create a process tree like:
+	//   /tmp/go-build3166037414/b001/pipe.test -test.paniconexit0 -test.timeout=10m0s -test.count=1 -test.run=Tree -test.v=true
+	//    \_ head -c 3G
+	//    \_ sh -c less; :
+	//        \_ less
+	// so that MemoryObserver is watching the parent `sh` proc and doesn't detect less's mem usage.
+	// less should buffer whatever we send it via stdin, giving us some level of control over its
+	// memory usage.
+	rss := testMemoryObserver(t, 400, pipe.Command("sh", "-c", "less; :"))
+	require.Greater(t, rss, 400_000_000)
+}
+
+func testMemoryObserver(t *testing.T, mbs int, stage pipe.Stage) int {
+	ctx := context.Background()
+
+	stdinReader, stdinWriter := io.Pipe()
+
+	devNull, err := os.OpenFile("/dev/null", os.O_WRONLY, 0)
+	require.NoError(t, err)
+
+	buf := &bytes.Buffer{}
+	logger := log.New(buf, "testMemoryObserver", log.Ldate|log.Ltime)
+
+	p := pipe.New(pipe.WithDir("/"), pipe.WithStdin(stdinReader), pipe.WithStdout(devNull))
+	p.Add(pipe.MemoryObserver(stage, LogEventHandler(logger)))
+	require.NoError(t, p.Start(ctx))
+
+	// Write some nonsense data to less, but don't close stdin until we want it
+	// to exit.
+	var bytes [1_000_000]byte
+	for i := 0; i < mbs; i++ {
+		n, err := stdinWriter.Write(bytes[:])
+		require.NoError(t, err)
+		require.Equal(t, len(bytes), n)
+	}
+
+	// MemoryObserver polls every one second, so this should make sure we catch
+	// at least one.
+	time.Sleep(2 * time.Second)
+
+	// Close stdin and wait for the pipeline to exit.
+	require.NoError(t, stdinWriter.Close())
+	require.NoError(t, p.Wait())
+
+	return maxBytes(buf.String())
+}
+
+func maxBytes(s string) int {
+	idx := strings.Index(s, "max_rss_bytes=")
+	if idx < 0 {
+		return idx
+	}
+	var maxRSS int
+	n, err := fmt.Sscanf(s[idx:], "max_rss_bytes=%d", &maxRSS)
+	if n != 1 || err != nil {
+		return -1
+	}
+	return maxRSS
+}
+
+func TestMemoryLimitSimple(t *testing.T) {
+	t.Parallel()
+	msg, err := testMemoryLimit(t, 400, 10_000_000, pipe.Command("less"))
+	assert.Contains(t, msg, "exceeded allowed memory")
+	assert.Contains(t, msg, "limit=10000000")
+	require.ErrorContains(t, err, "memory limit exceeded")
+}
+
+func TestMemoryLimitTreeMem(t *testing.T) {
+	t.Parallel()
+	msg, err := testMemoryLimit(t, 400, 10_000_000, pipe.Command("sh", "-c", "less; :"))
+	assert.Contains(t, msg, "exceeded allowed memory")
+	assert.Contains(t, msg, "limit=10000000")
+	require.ErrorContains(t, err, "memory limit exceeded")
+}
+
+type closeWrapper struct {
+	io.Writer
+	close func() error
+}
+
+func (w closeWrapper) Close() error {
+	return w.close()
+}
+
+func testMemoryLimit(t *testing.T, mbs int, limit uint64, stage pipe.Stage) (string, error) {
+	ctx := context.Background()
+
+	stdinReader, stdinWriter := io.Pipe()
+
+	devNull, err := os.OpenFile("/dev/null", os.O_WRONLY, 0)
+	require.NoError(t, err)
+
+	// io.Pipe doesn't know if anything is listening on the other end, so once
+	// our process is expectedly killed then we'll end up blocked trying to
+	// write to it. To workaround this, make sure we close the pipe reader when
+	// we've detected that the process has exited (i.e. when stdout has been
+	// closed). This will cause our write to immediately fail with this error.
+	closedErr := fmt.Errorf("stdout was closed")
+	stdout := closeWrapper{
+		Writer: devNull,
+		close: func() error {
+			require.NoError(t, stdinReader.CloseWithError(closedErr))
+			return nil
+		},
+	}
+
+	buf := &bytes.Buffer{}
+	logger := log.New(buf, "testMemoryObserver", log.Ldate|log.Ltime)
+
+	p := pipe.New(pipe.WithDir("/"), pipe.WithStdin(stdinReader), pipe.WithStdoutCloser(stdout))
+	p.Add(pipe.MemoryLimit(stage, limit, LogEventHandler(logger)))
+	require.NoError(t, p.Start(ctx))
+
+	// Write some nonsense data to less.
+	var bytes [1_000_000]byte
+	for i := 0; i < mbs; i++ {
+		_, err := stdinWriter.Write(bytes[:])
+		if err != nil {
+			require.ErrorIs(t, err, closedErr)
+		}
+	}
+
+	require.NoError(t, stdinWriter.Close())
+	err = p.Wait()
+
+	return buf.String(), err
+}

--- a/pipe/pipeline.go
+++ b/pipe/pipeline.go
@@ -168,6 +168,7 @@ type Event struct {
 	Command string
 	Msg     string
 	Err     error
+	Context map[string]interface{}
 }
 
 // WithEventHandler sets a handler for the pipeline. Setting one will emit


### PR DESCRIPTION
This pull moves the code introduced in this pull https://github.com/github/gitrpcd/pull/1063 into the go-pipe module.

Who would you want me to set as the author of the commit? I have just moved the code around and removed the dependency with the go-log and go-kvp libraries, so I would be happy to squash this into a single commit and set the proper author