### PR TITLE
Move golangci-lint-action to 3.7.0

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,7 +15,9 @@ jobs:
       - name: Vendor modules for later steps.
         run: |
           go mod vendor
-      - uses: golangci/golangci-lint-action@537aa1903e5d359d0b27dbc19ddd22c5087f3fbc # v3.2.0
+      - uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.49
+          version: v1.55
+          args:
+            -v

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,6 +30,18 @@ linters:
       - lll              # we allow any line length
       - unparam          # we allow function calls to name unused parameters
       - maligned         # clear structs are more important than saving a few bytes.
+
+linters-settings:
+  depguard:
+    rules:
+      main:
+        files:
+          - "$all"
+          - "!$test"
+        deny:
+          - pkg: io/ioutil
+            desc: The io/ioutil package has been deprecated, see https://go.dev/doc/go1.16#ioutil
+
 run:
   timeout: 5m
   skip-dirs:

--- a/pipe/command_linux.go
+++ b/pipe/command_linux.go
@@ -16,7 +16,7 @@ var (
 	errProcessInfoMissing = errors.New("cmd.Process is nil")
 )
 
-func (s *commandStage) GetRSSAnon(ctx context.Context) (uint64, error) {
+func (s *commandStage) GetRSSAnon(_ context.Context) (uint64, error) {
 	if s.cmd.Process == nil {
 		return 0, errProcessInfoMissing
 	}

--- a/pipe/iocopier.go
+++ b/pipe/iocopier.go
@@ -27,7 +27,7 @@ func (s *ioCopier) Name() string {
 }
 
 // This method always returns `nil, nil`.
-func (s *ioCopier) Start(ctx context.Context, _ Env, r io.ReadCloser) (io.ReadCloser, error) {
+func (s *ioCopier) Start(_ context.Context, _ Env, r io.ReadCloser) (io.ReadCloser, error) {
 	go func() {
 		_, err := io.Copy(s.w, r)
 		// We don't consider `ErrClosed` an error (FIXME: is this

--- a/pipe/pipeline_test.go
+++ b/pipe/pipeline_test.go
@@ -432,7 +432,7 @@ func (s ErrorStartingStage) Name() string {
 }
 
 func (s ErrorStartingStage) Start(
-	ctx context.Context, env pipe.Env, stdin io.ReadCloser,
+	_ context.Context, _ pipe.Env, _ io.ReadCloser,
 ) (io.ReadCloser, error) {
 	return io.NopCloser(&bytes.Buffer{}), s.err
 }
@@ -854,7 +854,7 @@ func BenchmarkTenFunctions(b *testing.B) {
 
 	dir := b.TempDir()
 
-	copy := func(_ context.Context, _ pipe.Env, stdin io.Reader, stdout io.Writer) error {
+	cp := func(_ context.Context, _ pipe.Env, stdin io.Reader, stdout io.Writer) error {
 		_, err := io.Copy(stdout, stdin)
 		return err
 	}
@@ -863,15 +863,15 @@ func BenchmarkTenFunctions(b *testing.B) {
 		p := pipe.New(pipe.WithDir(dir))
 		p.Add(
 			pipe.Println("hello world"),
-			pipe.Function("copy1", copy),
-			pipe.Function("copy2", copy),
-			pipe.Function("copy3", copy),
-			pipe.Function("copy4", copy),
-			pipe.Function("copy5", copy),
-			pipe.Function("copy6", copy),
-			pipe.Function("copy7", copy),
-			pipe.Function("copy8", copy),
-			pipe.Function("copy9", copy),
+			pipe.Function("copy1", cp),
+			pipe.Function("copy2", cp),
+			pipe.Function("copy3", cp),
+			pipe.Function("copy4", cp),
+			pipe.Function("copy5", cp),
+			pipe.Function("copy6", cp),
+			pipe.Function("copy7", cp),
+			pipe.Function("copy8", cp),
+			pipe.Function("copy9", cp),
 		)
 		out, err := p.Output(ctx)
 		if assert.NoError(b, err) {
@@ -885,7 +885,7 @@ func BenchmarkTenMixedStages(b *testing.B) {
 
 	dir := b.TempDir()
 
-	copy := func(_ context.Context, _ pipe.Env, stdin io.Reader, stdout io.Writer) error {
+	cp := func(_ context.Context, _ pipe.Env, stdin io.Reader, stdout io.Writer) error {
 		_, err := io.Copy(stdout, stdin)
 		return err
 	}
@@ -894,15 +894,15 @@ func BenchmarkTenMixedStages(b *testing.B) {
 		p := pipe.New(pipe.WithDir(dir))
 		p.Add(
 			pipe.Command("echo", "hello world"),
-			pipe.Function("copy1", copy),
+			pipe.Function("copy1", cp),
 			pipe.Command("cat"),
-			pipe.Function("copy2", copy),
+			pipe.Function("copy2", cp),
 			pipe.Command("cat"),
-			pipe.Function("copy3", copy),
+			pipe.Function("copy3", cp),
 			pipe.Command("cat"),
-			pipe.Function("copy4", copy),
+			pipe.Function("copy4", cp),
 			pipe.Command("cat"),
-			pipe.Function("copy5", copy),
+			pipe.Function("copy5", cp),
 		)
 		out, err := p.Output(ctx)
 		if assert.NoError(b, err) {


### PR DESCRIPTION
I have updated the golangci-lint action to the latest available version (and its linter counterpart).

Seems a few things have broken in the latest releases so I have introduced some tiny configurations in order to make it work (depguard). I have fixed the new linter errors