### PR TITLE
Give special handling to the first stage's stdin to prevent a deadlock

### DIFF
--- a/pipe/command.go
+++ b/pipe/command.go
@@ -69,7 +69,16 @@ func (s *commandStage) Start(
 	s.setupEnv(ctx, env)
 
 	if stdin != nil {
-		s.cmd.Stdin = stdin
+		// See the long comment in `Pipeline.Start()` for the
+		// explanation of this special case.
+		switch stdin := stdin.(type) {
+		case nopCloser:
+			s.cmd.Stdin = stdin.Reader
+		case nopCloserWriterTo:
+			s.cmd.Stdin = stdin.Reader
+		default:
+			s.cmd.Stdin = stdin
+		}
 		// Also keep a copy so that we can close it when the command exits:
 		s.stdin = stdin
 	}

--- a/pipe/nop_closer.go
+++ b/pipe/nop_closer.go
@@ -1,0 +1,34 @@
+// This file is mostly copied from the Go standard library, which is:
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+package pipe
+
+import "io"
+
+// newNopCloser returns a ReadCloser with a no-op Close method wrapping
+// the provided io.Reader r.
+// If r implements io.WriterTo, the returned io.ReadCloser will implement io.WriterTo
+// by forwarding calls to r.
+func newNopCloser(r io.Reader) io.ReadCloser {
+	if _, ok := r.(io.WriterTo); ok {
+		return nopCloserWriterTo{r}
+	}
+	return nopCloser{r}
+}
+
+type nopCloser struct {
+	io.Reader
+}
+
+func (nopCloser) Close() error { return nil }
+
+type nopCloserWriterTo struct {
+	io.Reader
+}
+
+func (nopCloserWriterTo) Close() error { return nil }
+
+func (c nopCloserWriterTo) WriteTo(w io.Writer) (n int64, err error) {
+	return c.Reader.(io.WriterTo).WriteTo(w)
+}

--- a/pipe/pipeline_test.go
+++ b/pipe/pipeline_test.go
@@ -115,6 +115,46 @@ func TestPipelineStdinFileThatIsNeverClosed(t *testing.T) {
 	assert.NoError(t, p.Run(ctx))
 }
 
+func TestPipelineStdinThatIsNeverClosed(t *testing.T) {
+	t.Skip("test not run because it currently deadlocks")
+
+	t.Parallel()
+
+	// Ideally, we'd want the subprocess to terminate on its own, as
+	// opposed to getting stuck waiting for stdin to close, because
+	// the subprocess doesn't read from its stdin.
+	//
+	// A second-best outcome would be that the program is killed
+	// cleanly by the context timeout, and the pipeline ends promptly.
+	//
+	// What actually happens is a deadlock :-(
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = w.Close()
+		_ = r.Close()
+	})
+
+	var stdout bytes.Buffer
+
+	// The point here is to wrap `r` so that `exec.Cmd` doesn't
+	// recognize that it's an `*os.File`:
+	p := pipe.New(
+		pipe.WithStdin(io.NopCloser(r)),
+		pipe.WithStdout(&stdout),
+	)
+	// Note that this command doesn't read from its stdin, so it will
+	// terminate regardless of whether `w` gets closed:
+	p.Add(pipe.Command("true"))
+
+	// An error here presumably means that the context has timed out,
+	// which shouldn't happen.
+	assert.NoError(t, p.Run(ctx))
+}
+
 func TestNontrivialPipeline(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()


### PR DESCRIPTION
The pipe's `stdin` needs to be wrapped with something like an `io.NopCloser()` to prevent the pipe from closing it.

We used to use `io.NopCloser()` for this purpose, but it has a subtle problem. If the first stage is a `Command`, then we wants to set the `exec.Cmd`'s `Stdin` to an `io.Reader` corresponding to `p.stdin`. If `Cmd.Stdin` is an `*os.File`, then the file descriptor can be passed to the subcommand directly; there is no need for this process to create a pipe and copy the data into the input side of the pipe. But if `p.stdin` is not an `*os.File`, then this optimization is prevented. And even worse, it also has the side effect that the goroutine that copies from `Cmd.Stdin` into the pipe doesn't terminate until that fd is closed by the writing side.

That isn't always what we want. Consider, for example, the following snippet, where the subcommand's stdin is set to the stdin of the enclosing Go program, but wrapped with `io.NopCloser`:

    cmd := exec.Command("ls")
    cmd.Stdin = io.NopCloser(os.Stdin)
    cmd.Stdout = os.Stdout
    cmd.Stderr = os.Stderr
    cmd.Run()

In this case, we don't want the Go program to wait for `os.Stdin` to close (because `ls` isn't even trying to read from its stdin). But it does: `exec.Cmd` doesn't recognize that `Cmd.Stdin` is an `*os.File`, so it sets up a pipe and copies the data itself, and this goroutine doesn't terminate until `cmd.Stdin` (i.e., the Go program's own stdin) is closed. But if, for example, the Go program is run from an interactive shell session, that might never happen, in which case the program will fail to terminate, even after `ls` exits.

So instead, in this special case, wrap `p.stdin` in our own `nopCloser`, which behaves like `io.NopCloser`, except that `pipe.CommandStage` knows how to unwrap it before passing it to `exec.Cmd`.

/cc @elhmn
