### PR TITLE
Fix minor grammar error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A package used to easily build command pipelines in your Go applications
 
 # Important
-We have not thoroughly tested this package on OS different to Linux, especially Windows. At this time, using this package on Windows based systems is considered experimental and will be supported only on a best effort basis.
+We have not thoroughly tested this package on OSs other than Linux, especially Windows. At this time, using this package on Windows based systems is considered experimental and will be supported only on a best effort basis.
 
 # Links
 


### PR DESCRIPTION
Made a minor fix to the grammar in this sentence: "We have not thoroughly tested this package on OS different to Linux, especially Windows."