### PR TITLE
Extends the Function Stage to Handle Panics

### DIFF
--- a/pipe/panic.go
+++ b/pipe/panic.go
@@ -1,7 +1,5 @@
 package pipe
 
-import "fmt"
-
 // StagePanicHandlerAware is an interface that Stages can implement to receive
 // a panic handler from the pipeline. This is particularly useful for stages
 // that execute work in a separate goroutine and need to manage panics occurring
@@ -11,17 +9,4 @@ type StagePanicHandlerAware interface {
 }
 
 // StagePanicHandler is a function that handles panics in a pipeline's stages.
-type StagePanicHandler func(err error)
-
-// FromPanicValue converts a panic value to an error. If the panic value is
-// already an error, it returns it directly. Otherwise, it wraps the value in
-// a generic error.
-func FromPanicValue(p any) error {
-	var err error
-	if e, ok := p.(error); ok {
-		err = e
-	} else {
-		err = fmt.Errorf("%v", p)
-	}
-	return err
-}
+type StagePanicHandler func(p any) error

--- a/pipe/panic.go
+++ b/pipe/panic.go
@@ -1,0 +1,27 @@
+package pipe
+
+import "fmt"
+
+// StagePanicHandlerAware is an interface that Stages can implement to receive
+// a panic handler from the pipeline. This is particularly useful for stages
+// that execute work in a separate goroutine and need to manage panics occurring
+// within that goroutine.
+type StagePanicHandlerAware interface {
+	SetPanicHandler(StagePanicHandler)
+}
+
+// StagePanicHandler is a function that handles panics in a pipeline's stages.
+type StagePanicHandler func(err error)
+
+// FromPanicValue converts a panic value to an error. If the panic value is
+// already an error, it returns it directly. Otherwise, it wraps the value in
+// a generic error.
+func FromPanicValue(p any) error {
+	var err error
+	if e, ok := p.(error); ok {
+		err = e
+	} else {
+		err = fmt.Errorf("%v", p)
+	}
+	return err
+}

--- a/pipe/pipeline_test.go
+++ b/pipe/pipeline_test.go
@@ -462,12 +462,11 @@ func TestFunction(t *testing.T) {
 	})
 
 	t.Run("panic with handler", func(t *testing.T) {
-		panicked := make(chan bool, 1)
+		panickedMessage := make(chan error, 1)
 		p := pipe.New(
 			pipe.WithDir(dir),
 			pipe.WithStagePanicHandler(func(err error) {
-				panicked <- true
-				assert.Equal(t, "this is a panic", err.Error())
+				panickedMessage <- err
 			}),
 		)
 		p.Add(
@@ -481,7 +480,7 @@ func TestFunction(t *testing.T) {
 		)
 
 		out, err := p.Output(ctx)
-		assert.True(t, <-panicked)
+		assert.Error(t, <-panickedMessage)
 		assert.Error(t, err)
 		assert.Empty(t, out)
 	})

--- a/pipe/pipeline_test.go
+++ b/pipe/pipeline_test.go
@@ -462,11 +462,11 @@ func TestFunction(t *testing.T) {
 	})
 
 	t.Run("panic with handler", func(t *testing.T) {
-		panickedMessage := make(chan error, 1)
 		p := pipe.New(
 			pipe.WithDir(dir),
-			pipe.WithStagePanicHandler(func(err error) {
-				panickedMessage <- err
+			pipe.WithStagePanicHandler(func(p any) error {
+				err := fmt.Errorf("panic handled: %v", p)
+				return err
 			}),
 		)
 		p.Add(
@@ -480,8 +480,7 @@ func TestFunction(t *testing.T) {
 		)
 
 		out, err := p.Output(ctx)
-		assert.Error(t, <-panickedMessage)
-		assert.Error(t, err)
+		assert.ErrorContains(t, err, "panic handled")
 		assert.Empty(t, out)
 	})
 }


### PR DESCRIPTION
## Overview

Certain stages, such as `pipe.Function` take in a client function to run. In the event of a panic, the client code cannot handle  any panics that happen in the client function because it is run in a separate goroutine.

This PR introduces a panic handler mechanism with the intent of surfacing the panic to the client so that they can react to it accordingly, if they wish. Currently only the `pipe.Function` will support this new behavior as it was the most likely contender for causing panics as it allows any client go code to be run. 

## Implementation

- Adds a light `StagePanicHandlerAware` interface that is used to mark stages as capable of receiving a panic handler.
- Updates `pipe.Function` with panic recover code. If a panic handler was provided at the pipeline level, it will be called. Otherwise the panic will bubble up as before.
- Extends `pipe.Pipeline` with a new `WithStagePanicHandler` option to allow clients to set a panic handler. The handler is passed into stages that support the `StagePanicHandlerAware` interface.

## Example

```go
p := pipe.New(
  pipe.WithDir(dir),
  pipe.WithStagePanicHandler(func(err error) {
	logger.Error("encountered panic: %v", err)
        // Other recovery logic and/or re-panic
  }),
)

p.Add(
  pipe.Print("hello world"),
  pipe.Function(
	"farewell",
	func(_ context.Context, _ pipe.Env, stdin io.Reader, stdout io.Writer) error {
		// Client function that caused panic
	},
  ),
)
```