### PR TITLE
ignore errProcessInfoMissing when getting process RSS

### DIFF
--- a/internal/ptree/ptree.go
+++ b/internal/ptree/ptree.go
@@ -24,6 +24,10 @@ var (
 func GetProcessRSSAnon(pid int) (uint64, error) {
 	status := fmt.Sprintf("%d/status", pid)
 	f, err := procfs.Open(status)
+	if os.IsNotExist(err) {
+		// process is already gone
+		return 0, nil
+	}
 	if err != nil {
 		return 0, err
 	}

--- a/pipe/memorylimit.go
+++ b/pipe/memorylimit.go
@@ -58,7 +58,7 @@ func killAtLimit(byteLimit uint64, eventHandler func(e *Event)) memoryWatchFunc 
 				return
 			case <-t.C:
 				rss, err := stage.GetRSSAnon(ctx)
-				if err != nil && err != errProcessInfoMissing {
+				if err != nil && !errors.Is(err, errProcessInfoMissing) {
 					consecutiveErrors++
 					if consecutiveErrors >= 2 {
 						eventHandler(&Event{

--- a/pipe/memorylimit.go
+++ b/pipe/memorylimit.go
@@ -58,7 +58,7 @@ func killAtLimit(byteLimit uint64, eventHandler func(e *Event)) memoryWatchFunc 
 				return
 			case <-t.C:
 				rss, err := stage.GetRSSAnon(ctx)
-				if err != nil {
+				if err != nil && err != errProcessInfoMissing {
 					consecutiveErrors++
 					if consecutiveErrors >= 2 {
 						eventHandler(&Event{


### PR DESCRIPTION
We have [spikes of `error getting RSS` errors](https://splunk.githubapp.com/en-US/app/github_git_systems/search?q=search%20index%3Dprod-gitrpcd%20gh.gitrpcd.command%3Ddgit-update%20SeverityText%3DERROR%0A%7C%20timechart%20count%20by%20Body&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=&earliest=1771075860&latest=1771079485&display.page.search.tab=visualizations&display.general.type=visualizations&sid=1771079498.39142_2B940D30-B8F0-4B83-8631-442ABBEB6E40) setting off the `gitrpcd/dgit-update-status` monitor. That shouldn't be failing 3pc.

[Another query](https://splunk.githubapp.com/en-US/app/github_git_systems/search?q=search%20index%3Dprod-gitrpcd%20gh.gitrpcd.command%3Ddgit-update%20SeverityText%3DERROR%0A%7C%20eval%20error%3Dreplace(%27gh.gitrpcd.error%27%2C%20%22%5Cd%2B%22%2C%20%22_%22)%0A%7C%20stats%20count%20by%20Body%2C%20error&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=&earliest=1771076340&latest=1771076700&display.page.search.tab=statistics&display.general.type=statistics&display.visualizations.charting.chart.stackMode=stacked&sid=1771080821.40177_2B940D30-B8F0-4B83-8631-442ABBEB6E40)