### PR TITLE
Move errProcessInfoMissing to platform-independent file

### DIFF
--- a/pipe/command.go
+++ b/pipe/command.go
@@ -15,6 +15,8 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+var errProcessInfoMissing = errors.New("cmd.Process is nil")
+
 // commandStage is a pipeline `Stage` based on running an external
 // command and piping the data through its stdin and stdout.
 type commandStage struct {

--- a/pipe/command_linux.go
+++ b/pipe/command_linux.go
@@ -4,17 +4,12 @@ package pipe
 
 import (
 	"context"
-	"errors"
 
 	"github.com/github/go-pipe/internal/ptree"
 )
 
 // On linux, we can limit or observe memory usage in command stages.
 var _ LimitableStage = (*commandStage)(nil)
-
-var (
-	errProcessInfoMissing = errors.New("cmd.Process is nil")
-)
 
 func (s *commandStage) GetRSSAnon(_ context.Context) (uint64, error) {
 	if s.cmd.Process == nil {


### PR DESCRIPTION
`errProcessInfoMissing` was defined in `command_linux.go` (linux-only build tag) but referenced from `memorylimit.go` which compiles on all platforms, causing a build failure on non-Linux systems.