### PR TITLE
pool io.Copy buffers in ioCopier to reduce GC pressure

### DIFF
--- a/pipe/iocopier.go
+++ b/pipe/iocopier.go
@@ -26,6 +26,10 @@ var copyBufPool = sync.Pool{
 	},
 }
 
+// readerOnly wraps an io.Reader, hiding any other interfaces (such as
+// WriterTo) so that io.CopyBuffer is forced to use the provided buffer.
+type readerOnly struct{ io.Reader }
+
 func newIOCopier(w io.WriteCloser) *ioCopier {
 	return &ioCopier{
 		w:    w,
@@ -41,7 +45,13 @@ func (s *ioCopier) Name() string {
 func (s *ioCopier) Start(_ context.Context, _ Env, r io.ReadCloser) (io.ReadCloser, error) {
 	go func() {
 		bp := copyBufPool.Get().(*[]byte)
-		_, err := io.CopyBuffer(s.w, r, *bp)
+		// Strip all interfaces except Read from r so that
+		// io.CopyBuffer always uses the provided pool buffer.
+		// Without this, *os.File's WriterTo (added in Go 1.26)
+		// causes CopyBuffer to call File.WriteTo, which falls
+		// back to io.Copy with a fresh allocation, bypassing
+		// the pool entirely.
+		_, err := io.CopyBuffer(s.w, readerOnly{r}, *bp)
 		copyBufPool.Put(bp)
 		// We don't consider `ErrClosed` an error (FIXME: is this
 		// correct?):

--- a/pipe/iocopier.go
+++ b/pipe/iocopier.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"sync"
 )
 
 // ioCopier is a stage that copies its stdin to a specified
@@ -13,6 +14,16 @@ type ioCopier struct {
 	w    io.WriteCloser
 	done chan struct{}
 	err  error
+}
+
+// copyBufPool reuses 32KB buffers across io.CopyBuffer calls, avoiding
+// a fresh heap allocation per copy. This matters in high-throughput
+// pipelines where many ioCopier stages run concurrently.
+var copyBufPool = sync.Pool{
+	New: func() any {
+		b := make([]byte, 32*1024)
+		return &b
+	},
 }
 
 func newIOCopier(w io.WriteCloser) *ioCopier {
@@ -29,7 +40,9 @@ func (s *ioCopier) Name() string {
 // This method always returns `nil, nil`.
 func (s *ioCopier) Start(_ context.Context, _ Env, r io.ReadCloser) (io.ReadCloser, error) {
 	go func() {
-		_, err := io.Copy(s.w, r)
+		bp := copyBufPool.Get().(*[]byte)
+		_, err := io.CopyBuffer(s.w, r, *bp)
+		copyBufPool.Put(bp)
 		// We don't consider `ErrClosed` an error (FIXME: is this
 		// correct?):
 		if err != nil && !errors.Is(err, os.ErrClosed) {

--- a/pipe/iocopier.go
+++ b/pipe/iocopier.go
@@ -44,15 +44,31 @@ func (s *ioCopier) Name() string {
 // This method always returns `nil, nil`.
 func (s *ioCopier) Start(_ context.Context, _ Env, r io.ReadCloser) (io.ReadCloser, error) {
 	go func() {
-		bp := copyBufPool.Get().(*[]byte)
-		// Strip all interfaces except Read from r so that
-		// io.CopyBuffer always uses the provided pool buffer.
-		// Without this, *os.File's WriterTo (added in Go 1.26)
-		// causes CopyBuffer to call File.WriteTo, which falls
-		// back to io.Copy with a fresh allocation, bypassing
-		// the pool entirely.
-		_, err := io.CopyBuffer(s.w, readerOnly{r}, *bp)
-		copyBufPool.Put(bp)
+		var err error
+
+		// Unwrap nopWriteCloser to see if the underlying writer
+		// supports ReaderFrom (e.g., for zero-copy network I/O).
+		var dst io.Writer = s.w
+		if nwc, ok := s.w.(nopWriteCloser); ok {
+			dst = nwc.Writer
+		}
+
+		if rf, ok := dst.(io.ReaderFrom); ok {
+			// Call ReadFrom directly, bypassing io.Copy's
+			// WriterTo check so that ReadFrom sees the
+			// original reader type (needed for zero-copy).
+			_, err = rf.ReadFrom(r)
+		} else {
+			bp := copyBufPool.Get().(*[]byte)
+			// Strip all interfaces except Read from r so that
+			// io.CopyBuffer always uses the provided pool buffer.
+			// Without this, *os.File's WriterTo (added in Go 1.26)
+			// causes CopyBuffer to call File.WriteTo, which falls
+			// back to io.Copy with a fresh allocation, bypassing
+			// the pool entirely.
+			_, err = io.CopyBuffer(dst, readerOnly{r}, *bp)
+			copyBufPool.Put(bp)
+		}
 		// We don't consider `ErrClosed` an error (FIXME: is this
 		// correct?):
 		if err != nil && !errors.Is(err, os.ErrClosed) {

--- a/pipe/iocopier_test.go
+++ b/pipe/iocopier_test.go
@@ -1,0 +1,75 @@
+package pipe
+
+import (
+	"bytes"
+	"os"
+	"runtime"
+	"testing"
+)
+
+// TestIOCopierPoolBufferUsed verifies that ioCopier uses the sync.Pool
+// buffer rather than allocating a fresh one. On Go 1.26+, *os.File
+// implements WriterTo, which causes io.CopyBuffer to bypass the
+// provided pool buffer entirely. Instead, File.WriteTo →
+// genericWriteTo → io.Copy allocates a fresh 32KB buffer on every call.
+func TestIOCopierPoolBufferUsed(t *testing.T) {
+	const payload = "hello from pipe\n"
+
+	// Pre-warm the pool so Get doesn't allocate.
+	copyBufPool.Put(copyBufPool.New())
+
+	// Warm up: run once to stabilize lazy init.
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		pw.Write([]byte(payload))
+		pw.Close()
+	}()
+	var warmBuf bytes.Buffer
+	c := newIOCopier(nopWriteCloser{&warmBuf})
+	c.Start(nil, Env{}, pr)
+	c.Wait()
+
+	// Now measure: run the copy and check how many bytes were allocated.
+	// If the pool buffer is bypassed, a fresh 32KB buffer is allocated.
+	pr, pw, err = os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		pw.Write([]byte(payload))
+		pw.Close()
+	}()
+	var buf bytes.Buffer
+	c = newIOCopier(nopWriteCloser{&buf})
+
+	// GC clears sync.Pool, so re-warm it afterward to isolate the
+	// measurement from pool repopulation overhead.
+	runtime.GC()
+	copyBufPool.Put(copyBufPool.New())
+
+	var m1, m2 runtime.MemStats
+	runtime.ReadMemStats(&m1)
+
+	c.Start(nil, Env{}, pr)
+	c.Wait()
+
+	runtime.GC()
+	runtime.ReadMemStats(&m2)
+
+	if buf.String() != payload {
+		t.Fatalf("unexpected output: %q", buf.String())
+	}
+
+	allocBytes := m2.TotalAlloc - m1.TotalAlloc
+	// A bypassed pool buffer causes ~32KB of allocation.
+	// With the pool buffer working, we expect well under 32KB.
+	const maxBytes = 16 * 1024
+	if allocBytes > maxBytes {
+		t.Errorf("ioCopier allocated %d bytes during copy (max %d); "+
+			"pool buffer may be bypassed by *os.File WriterTo",
+			allocBytes, maxBytes)
+	}
+}

--- a/pipe/iocopier_test.go
+++ b/pipe/iocopier_test.go
@@ -2,8 +2,10 @@ package pipe
 
 import (
 	"bytes"
+	"io"
 	"os"
 	"runtime"
+	"sync/atomic"
 	"testing"
 )
 
@@ -71,5 +73,49 @@ func TestIOCopierPoolBufferUsed(t *testing.T) {
 		t.Errorf("ioCopier allocated %d bytes during copy (max %d); "+
 			"pool buffer may be bypassed by *os.File WriterTo",
 			allocBytes, maxBytes)
+	}
+}
+
+// readFromWriter is a test writer that implements io.ReaderFrom and
+// records whether ReadFrom was called.
+type readFromWriter struct {
+	bytes.Buffer
+	readFromCalled atomic.Bool
+}
+
+func (w *readFromWriter) ReadFrom(r io.Reader) (int64, error) {
+	w.readFromCalled.Store(true)
+	return w.Buffer.ReadFrom(r)
+}
+
+func (w *readFromWriter) Close() error { return nil }
+
+// TestIOCopierUsesReadFrom verifies that ioCopier dispatches to
+// ReaderFrom when the destination writer supports it, even when
+// wrapped in nopWriteCloser (as happens with WithStdout).
+func TestIOCopierUsesReadFrom(t *testing.T) {
+	const payload = "hello readfrom\n"
+
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		pw.Write([]byte(payload))
+		pw.Close()
+	}()
+
+	w := &readFromWriter{}
+	c := newIOCopier(nopWriteCloser{w})
+	c.Start(nil, Env{}, pr)
+	c.Wait()
+
+	if w.Buffer.String() != payload {
+		t.Fatalf("unexpected output: %q", w.Buffer.String())
+	}
+
+	if !w.readFromCalled.Load() {
+		t.Error("ioCopier did not call ReadFrom on destination; " +
+			"nopWriteCloser may be hiding the ReaderFrom interface")
 	}
 }

--- a/pipe/iocopier_test.go
+++ b/pipe/iocopier_test.go
@@ -2,6 +2,7 @@ package pipe
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"os"
 	"runtime"
@@ -26,13 +27,13 @@ func TestIOCopierPoolBufferUsed(t *testing.T) {
 		t.Fatal(err)
 	}
 	go func() {
-		pw.Write([]byte(payload))
+		_, _ = pw.Write([]byte(payload))
 		pw.Close()
 	}()
 	var warmBuf bytes.Buffer
 	c := newIOCopier(nopWriteCloser{&warmBuf})
-	c.Start(nil, Env{}, pr)
-	c.Wait()
+	_, _ = c.Start(context.TODO(), Env{}, pr)
+	_ = c.Wait()
 
 	// Now measure: run the copy and check how many bytes were allocated.
 	// If the pool buffer is bypassed, a fresh 32KB buffer is allocated.
@@ -41,7 +42,7 @@ func TestIOCopierPoolBufferUsed(t *testing.T) {
 		t.Fatal(err)
 	}
 	go func() {
-		pw.Write([]byte(payload))
+		_, _ = pw.Write([]byte(payload))
 		pw.Close()
 	}()
 	var buf bytes.Buffer
@@ -55,8 +56,8 @@ func TestIOCopierPoolBufferUsed(t *testing.T) {
 	var m1, m2 runtime.MemStats
 	runtime.ReadMemStats(&m1)
 
-	c.Start(nil, Env{}, pr)
-	c.Wait()
+	_, _ = c.Start(context.TODO(), Env{}, pr)
+	_ = c.Wait()
 
 	runtime.GC()
 	runtime.ReadMemStats(&m2)
@@ -101,17 +102,17 @@ func TestIOCopierUsesReadFrom(t *testing.T) {
 		t.Fatal(err)
 	}
 	go func() {
-		pw.Write([]byte(payload))
+		_, _ = pw.Write([]byte(payload))
 		pw.Close()
 	}()
 
 	w := &readFromWriter{}
 	c := newIOCopier(nopWriteCloser{w})
-	c.Start(nil, Env{}, pr)
-	c.Wait()
+	_, _ = c.Start(context.TODO(), Env{}, pr)
+	_ = c.Wait()
 
-	if w.Buffer.String() != payload {
-		t.Fatalf("unexpected output: %q", w.Buffer.String())
+	if w.String() != payload {
+		t.Fatalf("unexpected output: %q", w.String())
 	}
 
 	if !w.readFromCalled.Load() {


### PR DESCRIPTION
While doing some perfomance analysis in one of our internal services I found that pipelines using the library showed relatively big allocation rates (12.6 MB/s).

`io.Copy` allocates a fresh 32KB buffer on every call when neither the reader nor writer implements ReadFrom/WriterTo, which is the common case for `ioCopier` since it typically copies between pipe file descriptors.

In high-throughput services this makes `io.copyBuffer` one of the top allocation sources. A 20-second heap profile showed 255MB allocated from io.copyBuffer, contributing ~12.6 MB/s of allocation pressure and driving GC worker saturation to ~70% of available procs per cycle.

The change introduced here  adds a `sync.Pool` of *[]byte (32KB, matching io.Copy's default) and use io.CopyBuffer with the pooled buffer. The buffer is returned to the pool after each copy completes.

This is a safe, drop-in change: `io.CopyBuffer` has identical semantics to `io.Copy` when a buffer is provided.