### PR TITLE
Enable sendfile for network destinations; fix pool bypass on Go 1.26+

### DIFF
--- a/pipe/iocopier.go
+++ b/pipe/iocopier.go
@@ -26,6 +26,10 @@ var copyBufPool = sync.Pool{
 	},
 }
 
+// readerOnly wraps an io.Reader, hiding any other interfaces (such as
+// WriterTo) so that io.CopyBuffer is forced to use the provided buffer.
+type readerOnly struct{ io.Reader }
+
 func newIOCopier(w io.WriteCloser) *ioCopier {
 	return &ioCopier{
 		w:    w,
@@ -41,7 +45,13 @@ func (s *ioCopier) Name() string {
 func (s *ioCopier) Start(_ context.Context, _ Env, r io.ReadCloser) (io.ReadCloser, error) {
 	go func() {
 		bp := copyBufPool.Get().(*[]byte)
-		_, err := io.CopyBuffer(s.w, r, *bp)
+		// Strip all interfaces except Read from r so that
+		// io.CopyBuffer always uses the provided pool buffer.
+		// Without this, *os.File's WriterTo (added in Go 1.26)
+		// causes CopyBuffer to call File.WriteTo, which falls
+		// back to io.Copy with a fresh allocation, bypassing
+		// the pool entirely.
+		_, err := io.CopyBuffer(s.w, readerOnly{r}, *bp)
 		copyBufPool.Put(bp)
 		// We don't consider `ErrClosed` an error (FIXME: is this
 		// correct?):

--- a/pipe/iocopier.go
+++ b/pipe/iocopier.go
@@ -44,15 +44,31 @@ func (s *ioCopier) Name() string {
 // This method always returns `nil, nil`.
 func (s *ioCopier) Start(_ context.Context, _ Env, r io.ReadCloser) (io.ReadCloser, error) {
 	go func() {
-		bp := copyBufPool.Get().(*[]byte)
-		// Strip all interfaces except Read from r so that
-		// io.CopyBuffer always uses the provided pool buffer.
-		// Without this, *os.File's WriterTo (added in Go 1.26)
-		// causes CopyBuffer to call File.WriteTo, which falls
-		// back to io.Copy with a fresh allocation, bypassing
-		// the pool entirely.
-		_, err := io.CopyBuffer(s.w, readerOnly{r}, *bp)
-		copyBufPool.Put(bp)
+		var err error
+
+		// Unwrap nopWriteCloser to see if the underlying writer
+		// supports ReaderFrom (e.g., for zero-copy network I/O).
+		var dst io.Writer = s.w
+		if nwc, ok := s.w.(nopWriteCloser); ok {
+			dst = nwc.Writer
+		}
+
+		if rf, ok := dst.(io.ReaderFrom); ok {
+			// Call ReadFrom directly, bypassing io.Copy's
+			// WriterTo check so that ReadFrom sees the
+			// original reader type (needed for zero-copy).
+			_, err = rf.ReadFrom(r)
+		} else {
+			bp := copyBufPool.Get().(*[]byte)
+			// Strip all interfaces except Read from r so that
+			// io.CopyBuffer always uses the provided pool buffer.
+			// Without this, *os.File's WriterTo (added in Go 1.26)
+			// causes CopyBuffer to call File.WriteTo, which falls
+			// back to io.Copy with a fresh allocation, bypassing
+			// the pool entirely.
+			_, err = io.CopyBuffer(dst, readerOnly{r}, *bp)
+			copyBufPool.Put(bp)
+		}
 		// We don't consider `ErrClosed` an error (FIXME: is this
 		// correct?):
 		if err != nil && !errors.Is(err, os.ErrClosed) {

--- a/pipe/iocopier_test.go
+++ b/pipe/iocopier_test.go
@@ -1,0 +1,75 @@
+package pipe
+
+import (
+	"bytes"
+	"os"
+	"runtime"
+	"testing"
+)
+
+// TestIOCopierPoolBufferUsed verifies that ioCopier uses the sync.Pool
+// buffer rather than allocating a fresh one. On Go 1.26+, *os.File
+// implements WriterTo, which causes io.CopyBuffer to bypass the
+// provided pool buffer entirely. Instead, File.WriteTo →
+// genericWriteTo → io.Copy allocates a fresh 32KB buffer on every call.
+func TestIOCopierPoolBufferUsed(t *testing.T) {
+	const payload = "hello from pipe\n"
+
+	// Pre-warm the pool so Get doesn't allocate.
+	copyBufPool.Put(copyBufPool.New())
+
+	// Warm up: run once to stabilize lazy init.
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		pw.Write([]byte(payload))
+		pw.Close()
+	}()
+	var warmBuf bytes.Buffer
+	c := newIOCopier(nopWriteCloser{&warmBuf})
+	c.Start(nil, Env{}, pr)
+	c.Wait()
+
+	// Now measure: run the copy and check how many bytes were allocated.
+	// If the pool buffer is bypassed, a fresh 32KB buffer is allocated.
+	pr, pw, err = os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		pw.Write([]byte(payload))
+		pw.Close()
+	}()
+	var buf bytes.Buffer
+	c = newIOCopier(nopWriteCloser{&buf})
+
+	// GC clears sync.Pool, so re-warm it afterward to isolate the
+	// measurement from pool repopulation overhead.
+	runtime.GC()
+	copyBufPool.Put(copyBufPool.New())
+
+	var m1, m2 runtime.MemStats
+	runtime.ReadMemStats(&m1)
+
+	c.Start(nil, Env{}, pr)
+	c.Wait()
+
+	runtime.GC()
+	runtime.ReadMemStats(&m2)
+
+	if buf.String() != payload {
+		t.Fatalf("unexpected output: %q", buf.String())
+	}
+
+	allocBytes := m2.TotalAlloc - m1.TotalAlloc
+	// A bypassed pool buffer causes ~32KB of allocation.
+	// With the pool buffer working, we expect well under 32KB.
+	const maxBytes = 16 * 1024
+	if allocBytes > maxBytes {
+		t.Errorf("ioCopier allocated %d bytes during copy (max %d); "+
+			"pool buffer may be bypassed by *os.File WriterTo",
+			allocBytes, maxBytes)
+	}
+}

--- a/pipe/iocopier_test.go
+++ b/pipe/iocopier_test.go
@@ -2,8 +2,10 @@ package pipe
 
 import (
 	"bytes"
+	"io"
 	"os"
 	"runtime"
+	"sync/atomic"
 	"testing"
 )
 
@@ -71,5 +73,49 @@ func TestIOCopierPoolBufferUsed(t *testing.T) {
 		t.Errorf("ioCopier allocated %d bytes during copy (max %d); "+
 			"pool buffer may be bypassed by *os.File WriterTo",
 			allocBytes, maxBytes)
+	}
+}
+
+// readFromWriter is a test writer that implements io.ReaderFrom and
+// records whether ReadFrom was called.
+type readFromWriter struct {
+	bytes.Buffer
+	readFromCalled atomic.Bool
+}
+
+func (w *readFromWriter) ReadFrom(r io.Reader) (int64, error) {
+	w.readFromCalled.Store(true)
+	return w.Buffer.ReadFrom(r)
+}
+
+func (w *readFromWriter) Close() error { return nil }
+
+// TestIOCopierUsesReadFrom verifies that ioCopier dispatches to
+// ReaderFrom when the destination writer supports it, even when
+// wrapped in nopWriteCloser (as happens with WithStdout).
+func TestIOCopierUsesReadFrom(t *testing.T) {
+	const payload = "hello readfrom\n"
+
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		pw.Write([]byte(payload))
+		pw.Close()
+	}()
+
+	w := &readFromWriter{}
+	c := newIOCopier(nopWriteCloser{w})
+	c.Start(nil, Env{}, pr)
+	c.Wait()
+
+	if w.Buffer.String() != payload {
+		t.Fatalf("unexpected output: %q", w.Buffer.String())
+	}
+
+	if !w.readFromCalled.Load() {
+		t.Error("ioCopier did not call ReadFrom on destination; " +
+			"nopWriteCloser may be hiding the ReaderFrom interface")
 	}
 }

--- a/pipe/iocopier_test.go
+++ b/pipe/iocopier_test.go
@@ -2,6 +2,7 @@ package pipe
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"os"
 	"runtime"
@@ -26,13 +27,13 @@ func TestIOCopierPoolBufferUsed(t *testing.T) {
 		t.Fatal(err)
 	}
 	go func() {
-		pw.Write([]byte(payload))
+		_, _ = pw.Write([]byte(payload))
 		pw.Close()
 	}()
 	var warmBuf bytes.Buffer
 	c := newIOCopier(nopWriteCloser{&warmBuf})
-	c.Start(nil, Env{}, pr)
-	c.Wait()
+	_, _ = c.Start(context.TODO(), Env{}, pr)
+	_ = c.Wait()
 
 	// Now measure: run the copy and check how many bytes were allocated.
 	// If the pool buffer is bypassed, a fresh 32KB buffer is allocated.
@@ -41,7 +42,7 @@ func TestIOCopierPoolBufferUsed(t *testing.T) {
 		t.Fatal(err)
 	}
 	go func() {
-		pw.Write([]byte(payload))
+		_, _ = pw.Write([]byte(payload))
 		pw.Close()
 	}()
 	var buf bytes.Buffer
@@ -55,8 +56,8 @@ func TestIOCopierPoolBufferUsed(t *testing.T) {
 	var m1, m2 runtime.MemStats
 	runtime.ReadMemStats(&m1)
 
-	c.Start(nil, Env{}, pr)
-	c.Wait()
+	_, _ = c.Start(context.TODO(), Env{}, pr)
+	_ = c.Wait()
 
 	runtime.GC()
 	runtime.ReadMemStats(&m2)
@@ -101,17 +102,17 @@ func TestIOCopierUsesReadFrom(t *testing.T) {
 		t.Fatal(err)
 	}
 	go func() {
-		pw.Write([]byte(payload))
+		_, _ = pw.Write([]byte(payload))
 		pw.Close()
 	}()
 
 	w := &readFromWriter{}
 	c := newIOCopier(nopWriteCloser{w})
-	c.Start(nil, Env{}, pr)
-	c.Wait()
+	_, _ = c.Start(context.TODO(), Env{}, pr)
+	_ = c.Wait()
 
-	if w.Buffer.String() != payload {
-		t.Fatalf("unexpected output: %q", w.Buffer.String())
+	if w.String() != payload {
+		t.Fatalf("unexpected output: %q", w.String())
 	}
 
 	if !w.readFromCalled.Load() {


### PR DESCRIPTION
Builds on #49 (`sync.Pool` for copy buffers). Two changes:

### 1. Enable sendfile for network destinations

When a pipeline's stdout is a writer with `ReadFrom` (e.g., `ConnWriter` wrapping `*net.TCPConn` in githttpdaemon), `ioCopier` now calls `ReadFrom` directly. For TCP destinations, this triggers `sendfile(2)` — the kernel copies data from the git process's stdout pipe to the TCP socket without it ever touching Go's heap:

```
Before:  git → kernel pipe → read() → Go heap (32KB) → write() → TCP socket
After:   git → kernel pipe → sendfile() → TCP socket
```

The key obstacle was `nopWriteCloser`: `WithStdout(w)` wraps the writer, hiding the `ReaderFrom` interface. The fix unwraps it in `ioCopier` before checking for `ReadFrom`.

This works on Go 1.24+ — `TCPConn.ReadFrom` has used sendfile for years.

### 2. Fix `sync.Pool` bypass on Go 1.26+

Go 1.26 added `WriterTo` to `*os.File`. When the source is an `*os.File` pipe (the common case for `CommandStage`), `io.CopyBuffer` detects `WriterTo` and calls `File.WriteTo` instead of using the provided pool buffer. `WriteTo`'s sendfile path fails (the destination isn't recognized as a network connection), so it falls back to `genericWriteTo → io.Copy` — which **allocates a fresh 32KB buffer**, completely bypassing the pool.

The fix wraps the reader in `readerOnly{io.Reader}` to strip `WriterTo`, forcing `io.CopyBuffer` to use the pool buffer. This only applies to the fallback path — when `ReadFrom` is available (change 1), it takes priority.

### Dispatch order in `ioCopier`

```
1. Unwrap nopWriteCloser
2. If dest has ReadFrom → call it directly (sendfile, etc.)
3. Else → pooled io.CopyBuffer with readerOnly wrapper
```
