### PR TITLE
Replace the MemoryLimit constructor trio with MemoryWatch + options

### DIFF
--- a/pipe/memorylimit.go
+++ b/pipe/memorylimit.go
@@ -249,14 +249,15 @@ func (m *memoryWatchStage) monitor(ctx context.Context, panicHandler StagePanicH
 
 	go func() {
 		defer m.wg.Done()
-		defer func() {
-			if p := recover(); p != nil {
-				if panicHandler == nil {
-					panic(p)
+
+		if panicHandler != nil {
+			defer func() {
+				if p := recover(); p != nil {
+					m.watchErr = panicHandler(p)
 				}
-				m.watchErr = panicHandler(p)
-			}
-		}()
+			}()
+		}
+
 		m.watch(ctx)
 	}()
 }

--- a/pipe/memorylimit.go
+++ b/pipe/memorylimit.go
@@ -98,85 +98,96 @@ func MemoryWatch(stage Stage, eventHandler func(e *Event), opts ...MemoryWatchOp
 }
 
 func (c *memoryWatchConfig) watchFunc(eventHandler func(e *Event)) memoryWatchFunc {
-	limit := c.limit
-	observe := c.observe
+	mw := memoryWatcher{
+		cfg:          c,
+		eventHandler: eventHandler,
+	}
 
-	return func(ctx context.Context, stage LimitableStage) {
-		var (
-			maxRSS                               uint64
-			samples, errCount, consecutiveErrors int
-			killed                               bool
-		)
+	return mw.watch
+}
 
-		t := time.NewTicker(memoryPollInterval)
-		defer t.Stop()
+type memoryWatcher struct {
+	cfg          *memoryWatchConfig
+	eventHandler func(e *Event)
 
-		for {
-			select {
-			case <-ctx.Done():
-				if observe {
-					eventHandler(&Event{
+	maxRSS            uint64
+	samples           int
+	errCount          int
+	consecutiveErrors int
+	killed            bool
+}
+
+// watch is a `memoryWatchFunc` that watches the memory usage of the
+// specified `stage`.
+func (mw *memoryWatcher) watch(ctx context.Context, stage LimitableStage) {
+	t := time.NewTicker(memoryPollInterval)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			if mw.cfg.observe {
+				mw.eventHandler(&Event{
+					Command: stage.Name(),
+					Msg:     "peak memory usage",
+					Context: map[string]interface{}{
+						"max_rss_bytes": mw.maxRSS,
+						"samples":       mw.samples,
+						"errors":        mw.errCount,
+					},
+				})
+			}
+			return
+		case <-t.C:
+			if mw.killed {
+				// After a kill we only remain in the loop to emit the
+				// peak-usage event at ctx.Done; stop sampling.
+				continue
+			}
+
+			rss, err := stage.GetRSSAnon(ctx)
+			if err != nil {
+				if !errors.Is(err, errProcessInfoMissing) {
+					mw.errCount++
+					mw.consecutiveErrors++
+					if mw.consecutiveErrors == 2 {
+						mw.eventHandler(&Event{
+							Command: stage.Name(),
+							Msg:     "error getting RSS",
+							Err:     err,
+						})
+					}
+				} else {
+					mw.consecutiveErrors = 0
+				}
+				continue
+			}
+
+			mw.consecutiveErrors = 0
+			mw.samples++
+			if rss > mw.maxRSS {
+				mw.maxRSS = rss
+			}
+
+			if mw.cfg.limit != nil && rss >= *mw.cfg.limit {
+				func() {
+					// Guarantee the over-limit stage is killed even if
+					// the user's event handler panics.
+					defer stage.Kill(ErrMemoryLimitExceeded)
+					mw.eventHandler(&Event{
 						Command: stage.Name(),
-						Msg:     "peak memory usage",
+						Msg:     "stage exceeded allowed memory use",
+						Err:     fmt.Errorf("stage exceeded allowed memory use"),
 						Context: map[string]interface{}{
-							"max_rss_bytes": maxRSS,
-							"samples":       samples,
-							"errors":        errCount,
+							"limit": *mw.cfg.limit,
+							"used":  rss,
 						},
 					})
+				}()
+				if !mw.cfg.observe {
+					return
 				}
-				return
-			case <-t.C:
-				if killed {
-					// After a kill we only remain in the loop to emit the
-					// peak-usage event at ctx.Done; stop sampling.
-					continue
-				}
-
-				rss, err := stage.GetRSSAnon(ctx)
-				if err != nil {
-					if !errors.Is(err, errProcessInfoMissing) {
-						errCount++
-						consecutiveErrors++
-						if consecutiveErrors == 2 {
-							eventHandler(&Event{
-								Command: stage.Name(),
-								Msg:     "error getting RSS",
-								Err:     err,
-							})
-						}
-					} else {
-						consecutiveErrors = 0
-					}
-					continue
-				}
-
-				consecutiveErrors = 0
-				samples++
-				if rss > maxRSS {
-					maxRSS = rss
-				}
-
-				if limit != nil && rss >= *limit {
-					func() {
-						// Guarantee the over-limit stage is killed even if
-						// the user's event handler panics.
-						defer stage.Kill(ErrMemoryLimitExceeded)
-						eventHandler(&Event{
-							Command: stage.Name(),
-							Msg:     "stage exceeded allowed memory use",
-							Err:     fmt.Errorf("stage exceeded allowed memory use"),
-							Context: map[string]interface{}{
-								"limit": *limit,
-								"used":  rss,
-							},
-						})
-					}()
-					if !observe {
-						return
-					}
-					killed = true
-				}
+				mw.killed = true
 			}
 		}
 	}

--- a/pipe/memorylimit.go
+++ b/pipe/memorylimit.go
@@ -87,6 +87,92 @@ func MemoryWatch(stage Stage, eventHandler func(e *Event), opts ...MemoryWatchOp
 	return &m
 }
 
+type memoryWatchStage struct {
+	nameSuffix   string
+	stage        LimitableStage
+	eventHandler func(e *Event)
+
+	limit   *uint64 // non-nil enables kill-at-limit
+	observe bool    // log peak RSS when the stage exits
+
+	maxRSS            uint64
+	samples           int
+	errCount          int
+	consecutiveErrors int
+
+	cancel   context.CancelFunc
+	wg       sync.WaitGroup
+	watchErr error
+}
+
+var _ LimitableStage = (*memoryWatchStage)(nil)
+
+func (m *memoryWatchStage) Name() string {
+	return m.stage.Name() + m.nameSuffix
+}
+
+func (m *memoryWatchStage) Preferences() StagePreferences {
+	return m.stage.Preferences()
+}
+
+func (m *memoryWatchStage) Start(
+	ctx context.Context, env Env, stdin io.ReadCloser, stdout io.WriteCloser, opts StartOptions,
+) error {
+	if err := m.stage.Start(ctx, env, stdin, stdout, opts); err != nil {
+		return err
+	}
+
+	m.monitor(ctx, opts.PanicHandler)
+
+	return nil
+}
+
+func (m *memoryWatchStage) Wait() error {
+	err := m.stage.Wait()
+	m.stopWatching()
+	if err == nil {
+		err = m.watchErr // non-nil if panicHandler() returned anything
+	}
+	return err
+}
+
+func (m *memoryWatchStage) GetRSSAnon(ctx context.Context) (uint64, error) {
+	return m.stage.GetRSSAnon(ctx)
+}
+
+func (m *memoryWatchStage) Kill(err error) {
+	m.stage.Kill(err)
+	m.stopWatching()
+}
+
+// monitor starts up a goroutine that monitors the memory of `m`. If
+// panicHandler is set, any panic that escapes the user-supplied event handler
+// (via m.watch) is recovered.
+func (m *memoryWatchStage) monitor(ctx context.Context, panicHandler StagePanicHandler) {
+	ctx, cancel := context.WithCancel(ctx)
+	m.cancel = cancel
+	m.wg.Add(1)
+
+	go func() {
+		defer m.wg.Done()
+
+		if panicHandler != nil {
+			defer func() {
+				if p := recover(); p != nil {
+					m.watchErr = panicHandler(p)
+				}
+			}()
+		}
+
+		m.watch(ctx)
+	}()
+}
+
+func (m *memoryWatchStage) stopWatching() {
+	m.cancel()
+	m.wg.Wait()
+}
+
 // watch is a `memoryWatchFunc` that watches the memory usage of the
 // specified `stage`.
 func (m *memoryWatchStage) watch(ctx context.Context) {
@@ -182,90 +268,4 @@ func (m *memoryWatchStage) reportPeakUsage() {
 			"errors":        m.errCount,
 		},
 	})
-}
-
-type memoryWatchStage struct {
-	nameSuffix   string
-	stage        LimitableStage
-	eventHandler func(e *Event)
-
-	limit   *uint64 // non-nil enables kill-at-limit
-	observe bool    // log peak RSS when the stage exits
-
-	maxRSS            uint64
-	samples           int
-	errCount          int
-	consecutiveErrors int
-
-	cancel   context.CancelFunc
-	wg       sync.WaitGroup
-	watchErr error
-}
-
-var _ LimitableStage = (*memoryWatchStage)(nil)
-
-func (m *memoryWatchStage) Name() string {
-	return m.stage.Name() + m.nameSuffix
-}
-
-func (m *memoryWatchStage) Preferences() StagePreferences {
-	return m.stage.Preferences()
-}
-
-func (m *memoryWatchStage) Start(
-	ctx context.Context, env Env, stdin io.ReadCloser, stdout io.WriteCloser, opts StartOptions,
-) error {
-	if err := m.stage.Start(ctx, env, stdin, stdout, opts); err != nil {
-		return err
-	}
-
-	m.monitor(ctx, opts.PanicHandler)
-
-	return nil
-}
-
-// monitor starts up a goroutine that monitors the memory of `m`. If
-// panicHandler is set, any panic that escapes the user-supplied event handler
-// (via m.watch) is recovered.
-func (m *memoryWatchStage) monitor(ctx context.Context, panicHandler StagePanicHandler) {
-	ctx, cancel := context.WithCancel(ctx)
-	m.cancel = cancel
-	m.wg.Add(1)
-
-	go func() {
-		defer m.wg.Done()
-
-		if panicHandler != nil {
-			defer func() {
-				if p := recover(); p != nil {
-					m.watchErr = panicHandler(p)
-				}
-			}()
-		}
-
-		m.watch(ctx)
-	}()
-}
-
-func (m *memoryWatchStage) Wait() error {
-	err := m.stage.Wait()
-	m.stopWatching()
-	if err == nil {
-		err = m.watchErr // non-nil if panicHandler() returned anything
-	}
-	return err
-}
-
-func (m *memoryWatchStage) GetRSSAnon(ctx context.Context) (uint64, error) {
-	return m.stage.GetRSSAnon(ctx)
-}
-
-func (m *memoryWatchStage) Kill(err error) {
-	m.stage.Kill(err)
-	m.stopWatching()
-}
-
-func (m *memoryWatchStage) stopWatching() {
-	m.cancel()
-	m.wg.Wait()
 }

--- a/pipe/memorylimit.go
+++ b/pipe/memorylimit.go
@@ -114,29 +114,19 @@ type memoryWatcher struct {
 	samples           int
 	errCount          int
 	consecutiveErrors int
-	killed            bool
 }
 
 // watch is a `memoryWatchFunc` that watches the memory usage of the
 // specified `stage`.
 func (mw *memoryWatcher) watch(ctx context.Context, stage LimitableStage) {
 	t := time.NewTicker(memoryPollInterval)
-	defer t.Stop()
 
+watchLoop:
 	for {
 		select {
 		case <-ctx.Done():
-			if mw.cfg.observe {
-				mw.reportPeakUsage(stage)
-			}
-			return
+			break watchLoop
 		case <-t.C:
-			if mw.killed {
-				// After a kill we only remain in the loop to emit the
-				// peak-usage event at ctx.Done; stop sampling.
-				continue
-			}
-
 			rss, err := stage.GetRSSAnon(ctx)
 			if err != nil {
 				mw.handleGetRSSError(stage, err)
@@ -152,12 +142,18 @@ func (mw *memoryWatcher) watch(ctx context.Context, stage LimitableStage) {
 			if mw.cfg.limit != nil && rss >= *mw.cfg.limit {
 				mw.killStage(stage, rss)
 
-				if !mw.cfg.observe {
-					return
-				}
-				mw.killed = true
+				// After a kill we wait for `ctx.Done()` and then emit
+				// the peak-usage event.
+				break watchLoop
 			}
 		}
+	}
+
+	t.Stop()
+
+	if mw.cfg.observe {
+		<-ctx.Done()
+		mw.reportPeakUsage(stage)
 	}
 }
 

--- a/pipe/memorylimit.go
+++ b/pipe/memorylimit.go
@@ -12,11 +12,11 @@ import (
 const memoryPollInterval = time.Second
 
 // ErrMemoryLimitExceeded is the error that will be used to kill a
-// process, if necessary, from MemoryLimit.
+// process, if necessary, from a MemoryWatch with WithMemoryLimit.
 var ErrMemoryLimitExceeded = errors.New("memory limit exceeded")
 
 // LimitableStage is the superset of `Stage` that must be implemented
-// by stages passed to MemoryLimit and MemoryObserver.
+// by stages passed to MemoryWatch.
 type LimitableStage interface {
 	Stage
 
@@ -24,108 +24,83 @@ type LimitableStage interface {
 	Kill(error)
 }
 
-// MemoryLimit watches the memory usage of the stage and stops it if it
-// exceeds the given limit.
+// MemoryWatchOption configures a MemoryWatch stage.
+type MemoryWatchOption func(*memoryWatchConfig)
+
+type memoryWatchConfig struct {
+	limit   *uint64 // non-nil enables kill-at-limit
+	observe bool    // log peak RSS when the stage exits
+}
+
+// WithMemoryLimit makes MemoryWatch kill the stage when its RSS exceeds
+// byteLimit.
+func WithMemoryLimit(byteLimit uint64) MemoryWatchOption {
+	return func(c *memoryWatchConfig) {
+		c.limit = &byteLimit
+	}
+}
+
+// WithPeakUsageLogging makes MemoryWatch log the peak RSS when the stage
+// exits.
+func WithPeakUsageLogging() MemoryWatchOption {
+	return func(c *memoryWatchConfig) {
+		c.observe = true
+	}
+}
+
+// MemoryWatch watches the memory usage of the stage and reports via
+// eventHandler. With WithMemoryLimit it kills the stage when the limit is
+// exceeded; with WithPeakUsageLogging it logs the peak RSS when the stage
+// exits. At least one of the two options is required.
 //
 // If the event handler panics while reporting the over-limit event, the
 // stage is still killed. A panic in any other event-handler call (an
-// RSS-read error) is recovered via StartOptions.PanicHandler and the
-// stage keeps running unmonitored; see StartOptions.PanicHandler.
-func MemoryLimit(stage Stage, byteLimit uint64, eventHandler func(e *Event)) Stage {
+// RSS-read error, or the peak-usage report) is recovered via
+// StartOptions.PanicHandler and the stage keeps running unmonitored; see
+// StartOptions.PanicHandler.
+func MemoryWatch(stage Stage, eventHandler func(e *Event), opts ...MemoryWatchOption) Stage {
+	var cfg memoryWatchConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
 
 	limitableStage, ok := stage.(LimitableStage)
 	if !ok {
 		eventHandler(&Event{
 			Command: stage.Name(),
-			Msg:     "invalid pipe.MemoryLimit usage",
-			Err:     fmt.Errorf("invalid pipe.MemoryLimit usage"),
+			Msg:     "invalid pipe.MemoryWatch usage",
+			Err:     fmt.Errorf("invalid pipe.MemoryWatch usage"),
 		})
 		return stage
 	}
 
-	return &memoryWatchStage{
-		nameSuffix: " with memory limit",
-		stage:      limitableStage,
-		watch:      killAtLimit(byteLimit, eventHandler),
-	}
-}
-
-func killAtLimit(byteLimit uint64, eventHandler func(e *Event)) memoryWatchFunc {
-	return func(ctx context.Context, stage LimitableStage) {
-		var consecutiveErrors int
-
-		t := time.NewTicker(memoryPollInterval)
-		defer t.Stop()
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-t.C:
-				rss, err := stage.GetRSSAnon(ctx)
-				if err != nil && !errors.Is(err, errProcessInfoMissing) {
-					consecutiveErrors++
-					if consecutiveErrors >= 2 {
-						eventHandler(&Event{
-							Command: stage.Name(),
-							Msg:     "error getting RSS",
-							Err:     err,
-						})
-					}
-					continue
-				}
-				consecutiveErrors = 0
-				if rss < byteLimit {
-					continue
-				}
-				func() {
-					// Guarantee the over-limit stage is killed even if
-					// the user's event handler panics.
-					defer stage.Kill(ErrMemoryLimitExceeded)
-					eventHandler(&Event{
-						Command: stage.Name(),
-						Msg:     "stage exceeded allowed memory use",
-						Err:     fmt.Errorf("stage exceeded allowed memory use"),
-						Context: map[string]interface{}{
-							"limit": byteLimit,
-							"used":  rss,
-						},
-					})
-				}()
-				return
-			}
-		}
-	}
-}
-
-// MemoryLimitWithObserver combines MemoryLimit and MemoryObserver in
-// one goroutine. It watches the memory usage of the stage, stops it
-// if it exceeds the given limit, and logs the peak memory usage when
-// the stage exits.
-//
-// Its event-handler panic behavior matches MemoryLimit: the over-limit
-// kill always happens, while a panic in the RSS-error or peak-usage
-// handler is recovered via StartOptions.PanicHandler and the stage keeps
-// running unmonitored. See StartOptions.PanicHandler.
-func MemoryLimitWithObserver(stage Stage, byteLimit uint64, eventHandler func(e *Event)) Stage {
-	limitableStage, ok := stage.(LimitableStage)
-	if !ok {
+	if cfg.limit == nil && !cfg.observe {
 		eventHandler(&Event{
 			Command: stage.Name(),
-			Msg:     "invalid pipe.MemoryLimitWithObserver usage",
-			Err:     fmt.Errorf("invalid pipe.MemoryLimitWithObserver usage"),
+			Msg:     "invalid pipe.MemoryWatch usage",
+			Err: fmt.Errorf(
+				"pipe.MemoryWatch requires WithMemoryLimit and/or WithPeakUsageLogging",
+			),
 		})
 		return stage
 	}
 
+	nameSuffix := ""
+	if cfg.limit != nil {
+		nameSuffix = " with memory limit"
+	}
+
 	return &memoryWatchStage{
-		nameSuffix: " with memory limit",
+		nameSuffix: nameSuffix,
 		stage:      limitableStage,
-		watch:      killAtLimitAndObserve(byteLimit, eventHandler),
+		watch:      cfg.watchFunc(eventHandler),
 	}
 }
 
-func killAtLimitAndObserve(byteLimit uint64, eventHandler func(e *Event)) memoryWatchFunc {
+func (c *memoryWatchConfig) watchFunc(eventHandler func(e *Event)) memoryWatchFunc {
+	limit := c.limit
+	observe := c.observe
+
 	return func(ctx context.Context, stage LimitableStage) {
 		var (
 			maxRSS                               uint64
@@ -139,18 +114,22 @@ func killAtLimitAndObserve(byteLimit uint64, eventHandler func(e *Event)) memory
 		for {
 			select {
 			case <-ctx.Done():
-				eventHandler(&Event{
-					Command: stage.Name(),
-					Msg:     "peak memory usage",
-					Context: map[string]interface{}{
-						"max_rss_bytes": maxRSS,
-						"samples":       samples,
-						"errors":        errCount,
-					},
-				})
+				if observe {
+					eventHandler(&Event{
+						Command: stage.Name(),
+						Msg:     "peak memory usage",
+						Context: map[string]interface{}{
+							"max_rss_bytes": maxRSS,
+							"samples":       samples,
+							"errors":        errCount,
+						},
+					})
+				}
 				return
 			case <-t.C:
 				if killed {
+					// After a kill we only remain in the loop to emit the
+					// peak-usage event at ctx.Done; stop sampling.
 					continue
 				}
 
@@ -178,7 +157,7 @@ func killAtLimitAndObserve(byteLimit uint64, eventHandler func(e *Event)) memory
 					maxRSS = rss
 				}
 
-				if rss >= byteLimit {
+				if limit != nil && rss >= *limit {
 					func() {
 						// Guarantee the over-limit stage is killed even if
 						// the user's event handler panics.
@@ -188,82 +167,15 @@ func killAtLimitAndObserve(byteLimit uint64, eventHandler func(e *Event)) memory
 							Msg:     "stage exceeded allowed memory use",
 							Err:     fmt.Errorf("stage exceeded allowed memory use"),
 							Context: map[string]interface{}{
-								"limit": byteLimit,
+								"limit": *limit,
 								"used":  rss,
 							},
 						})
 					}()
-					killed = true
-				}
-			}
-		}
-	}
-}
-
-// MemoryObserver watches memory use of the stage and logs the maximum
-// value when the stage exits.
-func MemoryObserver(stage Stage, eventHandler func(e *Event)) Stage {
-	limitableStage, ok := stage.(LimitableStage)
-	if !ok {
-		eventHandler(&Event{
-			Command: stage.Name(),
-			Msg:     "invalid pipe.MemoryObserver usage",
-			Err:     fmt.Errorf("invalid pipe.MemoryObserver usage"),
-		})
-		return stage
-	}
-
-	return &memoryWatchStage{
-		stage: limitableStage,
-		watch: logMaxRSS(eventHandler),
-	}
-}
-
-func logMaxRSS(eventHandler func(e *Event)) memoryWatchFunc {
-
-	return func(ctx context.Context, stage LimitableStage) {
-		var (
-			maxRSS                             uint64
-			samples, errors, consecutiveErrors int
-		)
-
-		t := time.NewTicker(memoryPollInterval)
-		defer t.Stop()
-
-		for {
-			select {
-			case <-ctx.Done():
-				eventHandler(&Event{
-					Command: stage.Name(),
-					Msg:     "peak memory usage",
-					Context: map[string]interface{}{
-						"max_rss_bytes": maxRSS,
-						"samples":       samples,
-						"errors":        errors,
-					},
-				})
-
-				return
-			case <-t.C:
-				rss, err := stage.GetRSSAnon(ctx)
-				if err != nil {
-					errors++
-					consecutiveErrors++
-					if consecutiveErrors == 2 {
-						eventHandler(&Event{
-							Command: stage.Name(),
-							Msg:     "error getting RSS",
-							Err:     err,
-						})
+					if !observe {
+						return
 					}
-					// don't log any more errors until we get rss successfully.
-					continue
-				}
-
-				consecutiveErrors = 0
-				samples++
-				if rss > maxRSS {
-					maxRSS = rss
+					killed = true
 				}
 			}
 		}

--- a/pipe/memorylimit.go
+++ b/pipe/memorylimit.go
@@ -112,6 +112,7 @@ type memoryWatcher struct {
 // specified `stage`.
 func (mw *memoryWatcher) watch(ctx context.Context) {
 	t := time.NewTicker(memoryPollInterval)
+	defer t.Stop()
 
 watchLoop:
 	for {
@@ -125,8 +126,6 @@ watchLoop:
 			}
 		}
 	}
-
-	t.Stop()
 
 	if mw.observe {
 		<-ctx.Done()

--- a/pipe/memorylimit.go
+++ b/pipe/memorylimit.go
@@ -25,26 +25,21 @@ type LimitableStage interface {
 }
 
 // MemoryWatchOption configures a MemoryWatch stage.
-type MemoryWatchOption func(*memoryWatchConfig)
-
-type memoryWatchConfig struct {
-	limit   *uint64 // non-nil enables kill-at-limit
-	observe bool    // log peak RSS when the stage exits
-}
+type MemoryWatchOption func(*memoryWatcher)
 
 // WithMemoryLimit makes MemoryWatch kill the stage when its RSS exceeds
 // byteLimit.
 func WithMemoryLimit(byteLimit uint64) MemoryWatchOption {
-	return func(c *memoryWatchConfig) {
-		c.limit = &byteLimit
+	return func(mw *memoryWatcher) {
+		mw.limit = &byteLimit
 	}
 }
 
 // WithPeakUsageLogging makes MemoryWatch log the peak RSS when the stage
 // exits.
 func WithPeakUsageLogging() MemoryWatchOption {
-	return func(c *memoryWatchConfig) {
-		c.observe = true
+	return func(mw *memoryWatcher) {
+		mw.observe = true
 	}
 }
 
@@ -59,11 +54,6 @@ func WithPeakUsageLogging() MemoryWatchOption {
 // StartOptions.PanicHandler and the stage keeps running unmonitored; see
 // StartOptions.PanicHandler.
 func MemoryWatch(stage Stage, eventHandler func(e *Event), opts ...MemoryWatchOption) Stage {
-	var cfg memoryWatchConfig
-	for _, opt := range opts {
-		opt(&cfg)
-	}
-
 	limitableStage, ok := stage.(LimitableStage)
 	if !ok {
 		eventHandler(&Event{
@@ -74,7 +64,15 @@ func MemoryWatch(stage Stage, eventHandler func(e *Event), opts ...MemoryWatchOp
 		return stage
 	}
 
-	if cfg.limit == nil && !cfg.observe {
+	mw := memoryWatcher{
+		stage:        limitableStage,
+		eventHandler: eventHandler,
+	}
+	for _, opt := range opts {
+		opt(&mw)
+	}
+
+	if mw.limit == nil && !mw.observe {
 		eventHandler(&Event{
 			Command: stage.Name(),
 			Msg:     "invalid pipe.MemoryWatch usage",
@@ -86,33 +84,23 @@ func MemoryWatch(stage Stage, eventHandler func(e *Event), opts ...MemoryWatchOp
 	}
 
 	nameSuffix := ""
-	if cfg.limit != nil {
+	if mw.limit != nil {
 		nameSuffix = " with memory limit"
 	}
 
 	return &memoryWatchStage{
 		nameSuffix: nameSuffix,
 		stage:      limitableStage,
-		watch:      cfg.watchFunc(limitableStage, eventHandler),
+		watch:      mw.watch,
 	}
-}
-
-func (c *memoryWatchConfig) watchFunc(
-	stage LimitableStage, eventHandler func(e *Event),
-) memoryWatchFunc {
-	mw := memoryWatcher{
-		cfg:          c,
-		stage:        stage,
-		eventHandler: eventHandler,
-	}
-
-	return mw.watch
 }
 
 type memoryWatcher struct {
-	cfg          *memoryWatchConfig
 	stage        LimitableStage
 	eventHandler func(e *Event)
+
+	limit   *uint64 // non-nil enables kill-at-limit
+	observe bool    // log peak RSS when the stage exits
 
 	maxRSS            uint64
 	samples           int
@@ -140,7 +128,7 @@ watchLoop:
 
 	t.Stop()
 
-	if mw.cfg.observe {
+	if mw.observe {
 		<-ctx.Done()
 		mw.reportPeakUsage()
 	}
@@ -161,7 +149,7 @@ func (mw *memoryWatcher) update(ctx context.Context) bool {
 		mw.maxRSS = rss
 	}
 
-	if mw.cfg.limit != nil && rss >= *mw.cfg.limit {
+	if mw.limit != nil && rss >= *mw.limit {
 		mw.killStage(rss)
 		return true
 	}
@@ -198,7 +186,7 @@ func (mw *memoryWatcher) killStage(rss uint64) {
 		Msg:     "stage exceeded allowed memory use",
 		Err:     fmt.Errorf("stage exceeded allowed memory use"),
 		Context: map[string]any{
-			"limit": *mw.cfg.limit,
+			"limit": *mw.limit,
 			"used":  rss,
 		},
 	})

--- a/pipe/memorylimit.go
+++ b/pipe/memorylimit.go
@@ -25,20 +25,21 @@ type LimitableStage interface {
 }
 
 // MemoryWatchOption configures a MemoryWatch stage.
-type MemoryWatchOption func(*memoryWatcher)
+type MemoryWatchOption func(*memoryWatchStage)
 
 // WithMemoryLimit makes MemoryWatch kill the stage when its RSS exceeds
 // byteLimit.
 func WithMemoryLimit(byteLimit uint64) MemoryWatchOption {
-	return func(mw *memoryWatcher) {
+	return func(mw *memoryWatchStage) {
 		mw.limit = &byteLimit
+		mw.nameSuffix = " with memory limit"
 	}
 }
 
 // WithPeakUsageLogging makes MemoryWatch log the peak RSS when the stage
 // exits.
 func WithPeakUsageLogging() MemoryWatchOption {
-	return func(mw *memoryWatcher) {
+	return func(mw *memoryWatchStage) {
 		mw.observe = true
 	}
 }
@@ -64,7 +65,7 @@ func MemoryWatch(stage Stage, eventHandler func(e *Event), opts ...MemoryWatchOp
 		return stage
 	}
 
-	mw := memoryWatcher{
+	mw := memoryWatchStage{
 		stage:        limitableStage,
 		eventHandler: eventHandler,
 	}
@@ -83,34 +84,12 @@ func MemoryWatch(stage Stage, eventHandler func(e *Event), opts ...MemoryWatchOp
 		return stage
 	}
 
-	nameSuffix := ""
-	if mw.limit != nil {
-		nameSuffix = " with memory limit"
-	}
-
-	return &memoryWatchStage{
-		nameSuffix: nameSuffix,
-		stage:      limitableStage,
-		watch:      mw.watch,
-	}
-}
-
-type memoryWatcher struct {
-	stage        LimitableStage
-	eventHandler func(e *Event)
-
-	limit   *uint64 // non-nil enables kill-at-limit
-	observe bool    // log peak RSS when the stage exits
-
-	maxRSS            uint64
-	samples           int
-	errCount          int
-	consecutiveErrors int
+	return &mw
 }
 
 // watch is a `memoryWatchFunc` that watches the memory usage of the
 // specified `stage`.
-func (mw *memoryWatcher) watch(ctx context.Context) {
+func (mw *memoryWatchStage) watch(ctx context.Context) {
 	t := time.NewTicker(memoryPollInterval)
 	defer t.Stop()
 
@@ -135,7 +114,7 @@ watchLoop:
 
 // update samples the current memory usage and updates internal stats.
 // Return true if the stage was killed for exceeding the memory limit.
-func (mw *memoryWatcher) update(ctx context.Context) bool {
+func (mw *memoryWatchStage) update(ctx context.Context) bool {
 	rss, err := mw.stage.GetRSSAnon(ctx)
 	if err != nil {
 		mw.handleGetRSSError(err)
@@ -158,7 +137,7 @@ func (mw *memoryWatcher) update(ctx context.Context) bool {
 
 // handleGetRSSError deals with error `err` that happened when trying
 // to get `stage`'s memory usage.
-func (mw *memoryWatcher) handleGetRSSError(err error) {
+func (mw *memoryWatchStage) handleGetRSSError(err error) {
 	if !errors.Is(err, errProcessInfoMissing) {
 		mw.errCount++
 		mw.consecutiveErrors++
@@ -175,7 +154,7 @@ func (mw *memoryWatcher) handleGetRSSError(err error) {
 }
 
 // killStage kills the stage and reports and event saying what it did.
-func (mw *memoryWatcher) killStage(rss uint64) {
+func (mw *memoryWatchStage) killStage(rss uint64) {
 	// Guarantee the over-limit stage is killed even if
 	// the user's event handler panics.
 	defer mw.stage.Kill(ErrMemoryLimitExceeded)
@@ -193,7 +172,7 @@ func (mw *memoryWatcher) killStage(rss uint64) {
 
 // reportPeakUsage sends an event reporting the peak usage that has
 // been seen for `stage`.
-func (mw *memoryWatcher) reportPeakUsage() {
+func (mw *memoryWatchStage) reportPeakUsage() {
 	mw.eventHandler(&Event{
 		Command: mw.stage.Name(),
 		Msg:     "peak memory usage",
@@ -206,15 +185,22 @@ func (mw *memoryWatcher) reportPeakUsage() {
 }
 
 type memoryWatchStage struct {
-	nameSuffix string
-	stage      LimitableStage
-	watch      memoryWatchFunc
-	cancel     context.CancelFunc
-	wg         sync.WaitGroup
-	watchErr   error
-}
+	nameSuffix   string
+	stage        LimitableStage
+	eventHandler func(e *Event)
 
-type memoryWatchFunc func(context.Context)
+	limit   *uint64 // non-nil enables kill-at-limit
+	observe bool    // log peak RSS when the stage exits
+
+	maxRSS            uint64
+	samples           int
+	errCount          int
+	consecutiveErrors int
+
+	cancel   context.CancelFunc
+	wg       sync.WaitGroup
+	watchErr error
+}
 
 var _ LimitableStage = (*memoryWatchStage)(nil)
 

--- a/pipe/memorylimit.go
+++ b/pipe/memorylimit.go
@@ -30,17 +30,17 @@ type MemoryWatchOption func(*memoryWatchStage)
 // WithMemoryLimit makes MemoryWatch kill the stage when its RSS exceeds
 // byteLimit.
 func WithMemoryLimit(byteLimit uint64) MemoryWatchOption {
-	return func(mw *memoryWatchStage) {
-		mw.limit = &byteLimit
-		mw.nameSuffix = " with memory limit"
+	return func(m *memoryWatchStage) {
+		m.limit = &byteLimit
+		m.nameSuffix = " with memory limit"
 	}
 }
 
 // WithPeakUsageLogging makes MemoryWatch log the peak RSS when the stage
 // exits.
 func WithPeakUsageLogging() MemoryWatchOption {
-	return func(mw *memoryWatchStage) {
-		mw.observe = true
+	return func(m *memoryWatchStage) {
+		m.observe = true
 	}
 }
 
@@ -65,15 +65,15 @@ func MemoryWatch(stage Stage, eventHandler func(e *Event), opts ...MemoryWatchOp
 		return stage
 	}
 
-	mw := memoryWatchStage{
+	m := memoryWatchStage{
 		stage:        limitableStage,
 		eventHandler: eventHandler,
 	}
 	for _, opt := range opts {
-		opt(&mw)
+		opt(&m)
 	}
 
-	if mw.limit == nil && !mw.observe {
+	if m.limit == nil && !m.observe {
 		eventHandler(&Event{
 			Command: stage.Name(),
 			Msg:     "invalid pipe.MemoryWatch usage",
@@ -84,12 +84,12 @@ func MemoryWatch(stage Stage, eventHandler func(e *Event), opts ...MemoryWatchOp
 		return stage
 	}
 
-	return &mw
+	return &m
 }
 
 // watch is a `memoryWatchFunc` that watches the memory usage of the
 // specified `stage`.
-func (mw *memoryWatchStage) watch(ctx context.Context) {
+func (m *memoryWatchStage) watch(ctx context.Context) {
 	t := time.NewTicker(memoryPollInterval)
 	defer t.Stop()
 
@@ -99,36 +99,36 @@ watchLoop:
 		case <-ctx.Done():
 			break watchLoop
 		case <-t.C:
-			if mw.update(ctx) {
+			if m.update(ctx) {
 				// The stage was killed.
 				break watchLoop
 			}
 		}
 	}
 
-	if mw.observe {
+	if m.observe {
 		<-ctx.Done()
-		mw.reportPeakUsage()
+		m.reportPeakUsage()
 	}
 }
 
 // update samples the current memory usage and updates internal stats.
 // Return true if the stage was killed for exceeding the memory limit.
-func (mw *memoryWatchStage) update(ctx context.Context) bool {
-	rss, err := mw.stage.GetRSSAnon(ctx)
+func (m *memoryWatchStage) update(ctx context.Context) bool {
+	rss, err := m.stage.GetRSSAnon(ctx)
 	if err != nil {
-		mw.handleGetRSSError(err)
+		m.handleGetRSSError(err)
 		return false
 	}
 
-	mw.consecutiveErrors = 0
-	mw.samples++
-	if rss > mw.maxRSS {
-		mw.maxRSS = rss
+	m.consecutiveErrors = 0
+	m.samples++
+	if rss > m.maxRSS {
+		m.maxRSS = rss
 	}
 
-	if mw.limit != nil && rss >= *mw.limit {
-		mw.killStage(rss)
+	if m.limit != nil && rss >= *m.limit {
+		m.killStage(rss)
 		return true
 	}
 
@@ -137,34 +137,34 @@ func (mw *memoryWatchStage) update(ctx context.Context) bool {
 
 // handleGetRSSError deals with error `err` that happened when trying
 // to get `stage`'s memory usage.
-func (mw *memoryWatchStage) handleGetRSSError(err error) {
+func (m *memoryWatchStage) handleGetRSSError(err error) {
 	if !errors.Is(err, errProcessInfoMissing) {
-		mw.errCount++
-		mw.consecutiveErrors++
-		if mw.consecutiveErrors == 2 {
-			mw.eventHandler(&Event{
-				Command: mw.stage.Name(),
+		m.errCount++
+		m.consecutiveErrors++
+		if m.consecutiveErrors == 2 {
+			m.eventHandler(&Event{
+				Command: m.stage.Name(),
 				Msg:     "error getting RSS",
 				Err:     err,
 			})
 		}
 	} else {
-		mw.consecutiveErrors = 0
+		m.consecutiveErrors = 0
 	}
 }
 
 // killStage kills the stage and reports and event saying what it did.
-func (mw *memoryWatchStage) killStage(rss uint64) {
+func (m *memoryWatchStage) killStage(rss uint64) {
 	// Guarantee the over-limit stage is killed even if
 	// the user's event handler panics.
-	defer mw.stage.Kill(ErrMemoryLimitExceeded)
+	defer m.stage.Kill(ErrMemoryLimitExceeded)
 
-	mw.eventHandler(&Event{
-		Command: mw.stage.Name(),
+	m.eventHandler(&Event{
+		Command: m.stage.Name(),
 		Msg:     "stage exceeded allowed memory use",
 		Err:     fmt.Errorf("stage exceeded allowed memory use"),
 		Context: map[string]any{
-			"limit": *mw.limit,
+			"limit": *m.limit,
 			"used":  rss,
 		},
 	})
@@ -172,14 +172,14 @@ func (mw *memoryWatchStage) killStage(rss uint64) {
 
 // reportPeakUsage sends an event reporting the peak usage that has
 // been seen for `stage`.
-func (mw *memoryWatchStage) reportPeakUsage() {
-	mw.eventHandler(&Event{
-		Command: mw.stage.Name(),
+func (m *memoryWatchStage) reportPeakUsage() {
+	m.eventHandler(&Event{
+		Command: m.stage.Name(),
 		Msg:     "peak memory usage",
 		Context: map[string]any{
-			"max_rss_bytes": mw.maxRSS,
-			"samples":       mw.samples,
-			"errors":        mw.errCount,
+			"max_rss_bytes": m.maxRSS,
+			"samples":       m.samples,
+			"errors":        m.errCount,
 		},
 	})
 }

--- a/pipe/memorylimit.go
+++ b/pipe/memorylimit.go
@@ -93,13 +93,16 @@ func MemoryWatch(stage Stage, eventHandler func(e *Event), opts ...MemoryWatchOp
 	return &memoryWatchStage{
 		nameSuffix: nameSuffix,
 		stage:      limitableStage,
-		watch:      cfg.watchFunc(eventHandler),
+		watch:      cfg.watchFunc(limitableStage, eventHandler),
 	}
 }
 
-func (c *memoryWatchConfig) watchFunc(eventHandler func(e *Event)) memoryWatchFunc {
+func (c *memoryWatchConfig) watchFunc(
+	stage LimitableStage, eventHandler func(e *Event),
+) memoryWatchFunc {
 	mw := memoryWatcher{
 		cfg:          c,
+		stage:        stage,
 		eventHandler: eventHandler,
 	}
 
@@ -108,6 +111,7 @@ func (c *memoryWatchConfig) watchFunc(eventHandler func(e *Event)) memoryWatchFu
 
 type memoryWatcher struct {
 	cfg          *memoryWatchConfig
+	stage        LimitableStage
 	eventHandler func(e *Event)
 
 	maxRSS            uint64
@@ -118,7 +122,7 @@ type memoryWatcher struct {
 
 // watch is a `memoryWatchFunc` that watches the memory usage of the
 // specified `stage`.
-func (mw *memoryWatcher) watch(ctx context.Context, stage LimitableStage) {
+func (mw *memoryWatcher) watch(ctx context.Context) {
 	t := time.NewTicker(memoryPollInterval)
 
 watchLoop:
@@ -127,7 +131,7 @@ watchLoop:
 		case <-ctx.Done():
 			break watchLoop
 		case <-t.C:
-			if mw.update(ctx, stage) {
+			if mw.update(ctx) {
 				// The stage was killed.
 				break watchLoop
 			}
@@ -138,16 +142,16 @@ watchLoop:
 
 	if mw.cfg.observe {
 		<-ctx.Done()
-		mw.reportPeakUsage(stage)
+		mw.reportPeakUsage()
 	}
 }
 
 // update samples the current memory usage and updates internal stats.
 // Return true if the stage was killed for exceeding the memory limit.
-func (mw *memoryWatcher) update(ctx context.Context, stage LimitableStage) bool {
-	rss, err := stage.GetRSSAnon(ctx)
+func (mw *memoryWatcher) update(ctx context.Context) bool {
+	rss, err := mw.stage.GetRSSAnon(ctx)
 	if err != nil {
-		mw.handleGetRSSError(stage, err)
+		mw.handleGetRSSError(err)
 		return false
 	}
 
@@ -158,7 +162,7 @@ func (mw *memoryWatcher) update(ctx context.Context, stage LimitableStage) bool 
 	}
 
 	if mw.cfg.limit != nil && rss >= *mw.cfg.limit {
-		mw.killStage(stage, rss)
+		mw.killStage(rss)
 		return true
 	}
 
@@ -167,13 +171,13 @@ func (mw *memoryWatcher) update(ctx context.Context, stage LimitableStage) bool 
 
 // handleGetRSSError deals with error `err` that happened when trying
 // to get `stage`'s memory usage.
-func (mw *memoryWatcher) handleGetRSSError(stage LimitableStage, err error) {
+func (mw *memoryWatcher) handleGetRSSError(err error) {
 	if !errors.Is(err, errProcessInfoMissing) {
 		mw.errCount++
 		mw.consecutiveErrors++
 		if mw.consecutiveErrors == 2 {
 			mw.eventHandler(&Event{
-				Command: stage.Name(),
+				Command: mw.stage.Name(),
 				Msg:     "error getting RSS",
 				Err:     err,
 			})
@@ -183,14 +187,14 @@ func (mw *memoryWatcher) handleGetRSSError(stage LimitableStage, err error) {
 	}
 }
 
-// killStage kills `stage` and reports and event saying what it did.
-func (mw *memoryWatcher) killStage(stage LimitableStage, rss uint64) {
+// killStage kills the stage and reports and event saying what it did.
+func (mw *memoryWatcher) killStage(rss uint64) {
 	// Guarantee the over-limit stage is killed even if
 	// the user's event handler panics.
-	defer stage.Kill(ErrMemoryLimitExceeded)
+	defer mw.stage.Kill(ErrMemoryLimitExceeded)
 
 	mw.eventHandler(&Event{
-		Command: stage.Name(),
+		Command: mw.stage.Name(),
 		Msg:     "stage exceeded allowed memory use",
 		Err:     fmt.Errorf("stage exceeded allowed memory use"),
 		Context: map[string]any{
@@ -202,9 +206,9 @@ func (mw *memoryWatcher) killStage(stage LimitableStage, rss uint64) {
 
 // reportPeakUsage sends an event reporting the peak usage that has
 // been seen for `stage`.
-func (mw *memoryWatcher) reportPeakUsage(stage LimitableStage) {
+func (mw *memoryWatcher) reportPeakUsage() {
 	mw.eventHandler(&Event{
-		Command: stage.Name(),
+		Command: mw.stage.Name(),
 		Msg:     "peak memory usage",
 		Context: map[string]any{
 			"max_rss_bytes": mw.maxRSS,
@@ -223,7 +227,7 @@ type memoryWatchStage struct {
 	watchErr   error
 }
 
-type memoryWatchFunc func(context.Context, LimitableStage)
+type memoryWatchFunc func(context.Context)
 
 var _ LimitableStage = (*memoryWatchStage)(nil)
 
@@ -265,7 +269,7 @@ func (m *memoryWatchStage) monitor(ctx context.Context, panicHandler StagePanicH
 				m.watchErr = panicHandler(p)
 			}
 		}()
-		m.watch(ctx, m.stage)
+		m.watch(ctx)
 	}()
 }
 

--- a/pipe/memorylimit.go
+++ b/pipe/memorylimit.go
@@ -127,23 +127,8 @@ watchLoop:
 		case <-ctx.Done():
 			break watchLoop
 		case <-t.C:
-			rss, err := stage.GetRSSAnon(ctx)
-			if err != nil {
-				mw.handleGetRSSError(stage, err)
-				continue
-			}
-
-			mw.consecutiveErrors = 0
-			mw.samples++
-			if rss > mw.maxRSS {
-				mw.maxRSS = rss
-			}
-
-			if mw.cfg.limit != nil && rss >= *mw.cfg.limit {
-				mw.killStage(stage, rss)
-
-				// After a kill we wait for `ctx.Done()` and then emit
-				// the peak-usage event.
+			if mw.update(ctx, stage) {
+				// The stage was killed.
 				break watchLoop
 			}
 		}
@@ -155,6 +140,29 @@ watchLoop:
 		<-ctx.Done()
 		mw.reportPeakUsage(stage)
 	}
+}
+
+// update samples the current memory usage and updates internal stats.
+// Return true if the stage was killed for exceeding the memory limit.
+func (mw *memoryWatcher) update(ctx context.Context, stage LimitableStage) bool {
+	rss, err := stage.GetRSSAnon(ctx)
+	if err != nil {
+		mw.handleGetRSSError(stage, err)
+		return false
+	}
+
+	mw.consecutiveErrors = 0
+	mw.samples++
+	if rss > mw.maxRSS {
+		mw.maxRSS = rss
+	}
+
+	if mw.cfg.limit != nil && rss >= *mw.cfg.limit {
+		mw.killStage(stage, rss)
+		return true
+	}
+
+	return false
 }
 
 // handleGetRSSError deals with error `err` that happened when trying

--- a/pipe/memorylimit.go
+++ b/pipe/memorylimit.go
@@ -127,15 +127,7 @@ func (mw *memoryWatcher) watch(ctx context.Context, stage LimitableStage) {
 		select {
 		case <-ctx.Done():
 			if mw.cfg.observe {
-				mw.eventHandler(&Event{
-					Command: stage.Name(),
-					Msg:     "peak memory usage",
-					Context: map[string]interface{}{
-						"max_rss_bytes": mw.maxRSS,
-						"samples":       mw.samples,
-						"errors":        mw.errCount,
-					},
-				})
+				mw.reportPeakUsage(stage)
 			}
 			return
 		case <-t.C:
@@ -147,19 +139,7 @@ func (mw *memoryWatcher) watch(ctx context.Context, stage LimitableStage) {
 
 			rss, err := stage.GetRSSAnon(ctx)
 			if err != nil {
-				if !errors.Is(err, errProcessInfoMissing) {
-					mw.errCount++
-					mw.consecutiveErrors++
-					if mw.consecutiveErrors == 2 {
-						mw.eventHandler(&Event{
-							Command: stage.Name(),
-							Msg:     "error getting RSS",
-							Err:     err,
-						})
-					}
-				} else {
-					mw.consecutiveErrors = 0
-				}
+				mw.handleGetRSSError(stage, err)
 				continue
 			}
 
@@ -170,20 +150,8 @@ func (mw *memoryWatcher) watch(ctx context.Context, stage LimitableStage) {
 			}
 
 			if mw.cfg.limit != nil && rss >= *mw.cfg.limit {
-				func() {
-					// Guarantee the over-limit stage is killed even if
-					// the user's event handler panics.
-					defer stage.Kill(ErrMemoryLimitExceeded)
-					mw.eventHandler(&Event{
-						Command: stage.Name(),
-						Msg:     "stage exceeded allowed memory use",
-						Err:     fmt.Errorf("stage exceeded allowed memory use"),
-						Context: map[string]interface{}{
-							"limit": *mw.cfg.limit,
-							"used":  rss,
-						},
-					})
-				}()
+				mw.killStage(stage, rss)
+
 				if !mw.cfg.observe {
 					return
 				}
@@ -191,6 +159,55 @@ func (mw *memoryWatcher) watch(ctx context.Context, stage LimitableStage) {
 			}
 		}
 	}
+}
+
+// handleGetRSSError deals with error `err` that happened when trying
+// to get `stage`'s memory usage.
+func (mw *memoryWatcher) handleGetRSSError(stage LimitableStage, err error) {
+	if !errors.Is(err, errProcessInfoMissing) {
+		mw.errCount++
+		mw.consecutiveErrors++
+		if mw.consecutiveErrors == 2 {
+			mw.eventHandler(&Event{
+				Command: stage.Name(),
+				Msg:     "error getting RSS",
+				Err:     err,
+			})
+		}
+	} else {
+		mw.consecutiveErrors = 0
+	}
+}
+
+// killStage kills `stage` and reports and event saying what it did.
+func (mw *memoryWatcher) killStage(stage LimitableStage, rss uint64) {
+	// Guarantee the over-limit stage is killed even if
+	// the user's event handler panics.
+	defer stage.Kill(ErrMemoryLimitExceeded)
+
+	mw.eventHandler(&Event{
+		Command: stage.Name(),
+		Msg:     "stage exceeded allowed memory use",
+		Err:     fmt.Errorf("stage exceeded allowed memory use"),
+		Context: map[string]any{
+			"limit": *mw.cfg.limit,
+			"used":  rss,
+		},
+	})
+}
+
+// reportPeakUsage sends an event reporting the peak usage that has
+// been seen for `stage`.
+func (mw *memoryWatcher) reportPeakUsage(stage LimitableStage) {
+	mw.eventHandler(&Event{
+		Command: stage.Name(),
+		Msg:     "peak memory usage",
+		Context: map[string]any{
+			"max_rss_bytes": mw.maxRSS,
+			"samples":       mw.samples,
+			"errors":        mw.errCount,
+		},
+	})
 }
 
 type memoryWatchStage struct {

--- a/pipe/memorylimit_panic_test.go
+++ b/pipe/memorylimit_panic_test.go
@@ -14,10 +14,12 @@ import (
 const memWatchPanicSentinel = "memwatch-panic-sentinel"
 const memWatchPanicChildEnv = "GO_PIPE_MEMWATCH_PANIC_CHILD"
 
-// fakeLimitableStage is a minimal LimitableStage whose Wait returns
-// immediately, letting a memoryWatchStage test exercise its watch
-// goroutine in isolation.
-type fakeLimitableStage struct{}
+// fakeLimitableStage is a minimal LimitableStage whose `GetRSSAnon()`
+// method panics, and whose `Wait()` method returns after that panic
+// has been issued.
+type fakeLimitableStage struct {
+	done chan struct{}
+}
 
 func (fakeLimitableStage) Name() string                  { return "fake" }
 func (fakeLimitableStage) Preferences() StagePreferences { return StagePreferences{} }
@@ -26,15 +28,23 @@ func (fakeLimitableStage) Start(
 ) error {
 	return nil
 }
-func (fakeLimitableStage) Wait() error                                { return nil }
-func (fakeLimitableStage) GetRSSAnon(context.Context) (uint64, error) { return 0, nil }
-func (fakeLimitableStage) Kill(error)                                 {}
+func (stage fakeLimitableStage) Wait() error {
+	<-stage.done
+	return nil
+}
 
-func panickingWatchStage() *memoryWatchStage {
-	return &memoryWatchStage{
-		stage: fakeLimitableStage{},
-		watch: func(context.Context) { panic(memWatchPanicSentinel) },
+func (stage fakeLimitableStage) GetRSSAnon(context.Context) (uint64, error) {
+	close(stage.done)
+	panic(memWatchPanicSentinel)
+}
+
+func (fakeLimitableStage) Kill(error) {}
+
+func panickingWatchStage() Stage {
+	stage := fakeLimitableStage{
+		done: make(chan struct{}),
 	}
+	return MemoryWatch(stage, func(*Event) {}, WithMemoryLimit(1))
 }
 
 // TestMemoryWatchStagePanicWithHandlerSurfaced verifies that a panic

--- a/pipe/memorylimit_panic_test.go
+++ b/pipe/memorylimit_panic_test.go
@@ -78,7 +78,7 @@ func TestMemoryWatchStagePanicWithHandlerSurfaced(t *testing.T) {
 // the panic would fail the test rather than hang on the ticker loop.
 func TestMemoryWatchStagePanicWithoutHandlerPropagates(t *testing.T) {
 	limit := uint64(1)
-	mw := memoryWatcher{
+	mw := memoryWatchStage{
 		stage:        fakeLimitableStage{done: make(chan struct{})},
 		eventHandler: func(*Event) {},
 		limit:        &limit,

--- a/pipe/memorylimit_panic_test.go
+++ b/pipe/memorylimit_panic_test.go
@@ -147,9 +147,12 @@ func (s *killTrackingStage) Kill(error) {
 // would never be killed and Wait would hang.
 func TestMemoryLimitKillsEvenIfEventHandlerPanics(t *testing.T) {
 	stage := newKillTrackingStage()
+	limit := uint64(1)
 	ms := &memoryWatchStage{
 		stage: stage,
-		watch: killAtLimit(1, func(*Event) { panic(memWatchPanicSentinel) }),
+		watch: (&memoryWatchConfig{limit: &limit}).watchFunc(
+			func(*Event) { panic(memWatchPanicSentinel) },
+		),
 	}
 	opts := StartOptions{
 		PanicHandler: func(p any) error { return fmt.Errorf("recovered: %v", p) },

--- a/pipe/memorylimit_panic_test.go
+++ b/pipe/memorylimit_panic_test.go
@@ -33,7 +33,7 @@ func (fakeLimitableStage) Kill(error)                                 {}
 func panickingWatchStage() *memoryWatchStage {
 	return &memoryWatchStage{
 		stage: fakeLimitableStage{},
-		watch: func(context.Context, LimitableStage) { panic(memWatchPanicSentinel) },
+		watch: func(context.Context) { panic(memWatchPanicSentinel) },
 	}
 }
 
@@ -151,7 +151,7 @@ func TestMemoryLimitKillsEvenIfEventHandlerPanics(t *testing.T) {
 	ms := &memoryWatchStage{
 		stage: stage,
 		watch: (&memoryWatchConfig{limit: &limit}).watchFunc(
-			func(*Event) { panic(memWatchPanicSentinel) },
+			stage, func(*Event) { panic(memWatchPanicSentinel) },
 		),
 	}
 	opts := StartOptions{

--- a/pipe/memorylimit_panic_test.go
+++ b/pipe/memorylimit_panic_test.go
@@ -148,11 +148,15 @@ func (s *killTrackingStage) Kill(error) {
 func TestMemoryLimitKillsEvenIfEventHandlerPanics(t *testing.T) {
 	stage := newKillTrackingStage()
 	limit := uint64(1)
+	eventHandler := func(*Event) { panic(memWatchPanicSentinel) }
+	mw := memoryWatcher{
+		stage:        stage,
+		eventHandler: eventHandler,
+		limit:        &limit,
+	}
 	ms := &memoryWatchStage{
 		stage: stage,
-		watch: (&memoryWatchConfig{limit: &limit}).watchFunc(
-			stage, func(*Event) { panic(memWatchPanicSentinel) },
-		),
+		watch: mw.watch,
 	}
 	opts := StartOptions{
 		PanicHandler: func(p any) error { return fmt.Errorf("recovered: %v", p) },

--- a/pipe/memorylimit_panic_test.go
+++ b/pipe/memorylimit_panic_test.go
@@ -4,15 +4,14 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
-	"os/exec"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const memWatchPanicSentinel = "memwatch-panic-sentinel"
-const memWatchPanicChildEnv = "GO_PIPE_MEMWATCH_PANIC_CHILD"
 
 // fakeLimitableStage is a minimal LimitableStage whose `GetRSSAnon()`
 // method panics, and whose `Wait()` method returns after that panic
@@ -70,47 +69,24 @@ func TestMemoryWatchStagePanicWithHandlerSurfaced(t *testing.T) {
 	}
 }
 
-// TestMemoryWatchStagePanicWithoutHandlerPropagates verifies that when
-// the memory-watch goroutine panics and no panic handler is installed,
-// the panic propagates (crashing the process) rather than being
-// silently swallowed. Because that would crash the test binary, the
-// scenario runs in a re-exec'd subprocess.
+// TestMemoryWatchStagePanicWithoutHandlerPropagates verifies that the
+// memory-watch sampling path does not swallow a panic. The monitor
+// goroutine only installs a recover when a handler is present (see
+// memoryWatchStage.monitor), so we exercise update() directly and assert
+// that it propagates the panic. update() is used rather than watch() so the
+// assertion is synchronous and ticker-independent: a regression that stopped
+// the panic would fail the test rather than hang on the ticker loop.
 func TestMemoryWatchStagePanicWithoutHandlerPropagates(t *testing.T) {
-	if os.Getenv(memWatchPanicChildEnv) == "1" {
-		runMemWatchPanicChild()
-		return
+	limit := uint64(1)
+	mw := memoryWatcher{
+		stage:        fakeLimitableStage{done: make(chan struct{})},
+		eventHandler: func(*Event) {},
+		limit:        &limit,
 	}
 
-	cmd := exec.Command(os.Args[0], "-test.run=^TestMemoryWatchStagePanicWithoutHandlerPropagates$", "-test.v") //nolint:gosec // re-exec of this test binary with constant arguments.
-	cmd.Env = append(os.Environ(), memWatchPanicChildEnv+"=1")
-	out, err := cmd.CombinedOutput()
-	output := string(out)
-
-	if err == nil {
-		t.Fatalf("expected subprocess to crash from a propagated panic, but it exited 0\noutput:\n%s", output)
-	}
-	if strings.Contains(output, "SURVIVED") {
-		t.Fatalf("panic was swallowed: Wait returned instead of propagating\noutput:\n%s", output)
-	}
-	if !strings.Contains(output, "panic:") || !strings.Contains(output, memWatchPanicSentinel) {
-		t.Fatalf("expected a propagated panic mentioning %q, got:\n%s", memWatchPanicSentinel, output)
-	}
-}
-
-func runMemWatchPanicChild() {
-	ms := panickingWatchStage()
-
-	if err := ms.Start(context.Background(), Env{}, nil, nil, StartOptions{}); err != nil {
-		os.Stdout.WriteString("SURVIVED: Start returned err=" + err.Error() + "\n")
-		os.Exit(0)
-	}
-
-	_ = ms.Wait()
-
-	// Reaching this point at all indicates the panic was swallowed.
-	time.Sleep(2 * time.Second)
-	os.Stdout.WriteString("SURVIVED: Wait returned\n")
-	os.Exit(0)
+	assert.PanicsWithValue(t, memWatchPanicSentinel, func() {
+		mw.update(context.Background())
+	})
 }
 
 // killTrackingStage is a LimitableStage that reports an over-limit RSS

--- a/pipe/memorylimit_panic_test.go
+++ b/pipe/memorylimit_panic_test.go
@@ -133,17 +133,8 @@ func (s *killTrackingStage) Kill(error) {
 // would never be killed and Wait would hang.
 func TestMemoryLimitKillsEvenIfEventHandlerPanics(t *testing.T) {
 	stage := newKillTrackingStage()
-	limit := uint64(1)
 	eventHandler := func(*Event) { panic(memWatchPanicSentinel) }
-	mw := memoryWatcher{
-		stage:        stage,
-		eventHandler: eventHandler,
-		limit:        &limit,
-	}
-	ms := &memoryWatchStage{
-		stage: stage,
-		watch: mw.watch,
-	}
+	ms := MemoryWatch(stage, eventHandler, WithMemoryLimit(1))
 	opts := StartOptions{
 		PanicHandler: func(p any) error { return fmt.Errorf("recovered: %v", p) },
 	}

--- a/pipe/memorylimit_test.go
+++ b/pipe/memorylimit_test.go
@@ -61,7 +61,7 @@ func testMemoryObserver(t *testing.T, mbs int, stage pipe.Stage) int {
 	logger := log.New(buf, "testMemoryObserver", log.Ldate|log.Ltime)
 
 	p := pipe.New(pipe.WithDir("/"), pipe.WithStdin(stdinReader), pipe.WithStdout(devNull))
-	p.Add(pipe.MemoryObserver(stage, LogEventHandler(logger)))
+	p.Add(pipe.MemoryWatch(stage, LogEventHandler(logger), pipe.WithPeakUsageLogging()))
 	require.NoError(t, p.Start(ctx))
 
 	// Write some nonsense data to less, but don't close stdin until we want it
@@ -168,7 +168,7 @@ func testMemoryLimitWithObserverBelowLimit(t *testing.T, mbs int, stage pipe.Sta
 	logger := log.New(buf, "testMemoryLimitWithObserverBelowLimit", log.Ldate|log.Ltime)
 
 	p := pipe.New(pipe.WithDir("/"), pipe.WithStdin(stdinReader), pipe.WithStdout(devNull))
-	p.Add(pipe.MemoryLimitWithObserver(stage, 100*1024*1024*1024, LogEventHandler(logger)))
+	p.Add(pipe.MemoryWatch(stage, LogEventHandler(logger), pipe.WithMemoryLimit(100*1024*1024*1024), pipe.WithPeakUsageLogging()))
 	require.NoError(t, p.Start(ctx))
 
 	var bytes [1_000_000]byte
@@ -218,7 +218,7 @@ func testMemoryLimit(t *testing.T, mbs int, limit uint64, stage pipe.Stage) (str
 				return nil
 			},
 		),
-		pipe.MemoryLimit(stage, limit, LogEventHandler(logger)),
+		pipe.MemoryWatch(stage, LogEventHandler(logger), pipe.WithMemoryLimit(limit)),
 	)
 	require.NoError(t, p.Start(ctx))
 
@@ -252,11 +252,27 @@ func testMemoryLimitWithObserver(t *testing.T, mbs int, limit uint64, stage pipe
 				return nil
 			},
 		),
-		pipe.MemoryLimitWithObserver(stage, limit, LogEventHandler(logger)),
+		pipe.MemoryWatch(stage, LogEventHandler(logger), pipe.WithMemoryLimit(limit), pipe.WithPeakUsageLogging()),
 	)
 	require.NoError(t, p.Start(ctx))
 
 	err = p.Wait()
 
 	return buf.String(), err
+}
+
+// TestMemoryWatchRequiresAnOption verifies that MemoryWatch without
+// WithMemoryLimit or WithPeakUsageLogging is rejected: it reports an
+// invalid-usage event and returns the stage unwrapped (no watcher).
+func TestMemoryWatchRequiresAnOption(t *testing.T) {
+	stage := pipe.Command("true")
+
+	var events []*pipe.Event
+	got := pipe.MemoryWatch(stage, func(e *pipe.Event) {
+		events = append(events, e)
+	})
+
+	require.Same(t, stage, got, "expected the input stage returned unwrapped")
+	require.Len(t, events, 1)
+	require.Contains(t, events[0].Msg, "invalid pipe.MemoryWatch usage")
 }


### PR DESCRIPTION
MemoryLimit, MemoryLimitWithObserver, and MemoryObserver were three positional-argument constructors expressing one concept: watch a stage's RSS, optionally enforce a limit, optionally log the peak. Collapse them into a single functional-options constructor:

    MemoryWatch(stage, eventHandler, WithMemoryLimit(n), WithPeakUsageLogging())

Calling MemoryWatch with neither option now reports an invalid-usage event and returns the stage unwrapped, mirroring the non-LimitableStage guard.

/cc @mhagger 