### PR TITLE
v2 review fixes for Pipe/runner branch

### DIFF
--- a/pipe/pipeline_test.go
+++ b/pipe/pipeline_test.go
@@ -54,6 +54,23 @@ func TestPipelineEmptyOutput(t *testing.T) {
 	}
 }
 
+func TestPipelineOutputClosesConfiguredStdoutCloser(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	stdout := &closeTrackingWriter{}
+	p := pipe.New(
+		pipe.WithStdin(strings.NewReader("hello world\n")),
+		pipe.WithStdoutCloser(stdout),
+	)
+
+	out, err := p.Output(ctx)
+	if assert.NoError(t, err) {
+		assert.Equal(t, "hello world\n", string(out))
+		assert.Equal(t, "", stdout.buf.String())
+		assert.True(t, stdout.closed, "WithStdoutCloser destination should be closed")
+	}
+}
+
 func TestPipelineEmptyWithStdoutCloser(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/pipe/runner.go
+++ b/pipe/runner.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 )
 
 // Env represents the environment that a pipeline stage should run in.
@@ -151,6 +152,10 @@ func (r *runner) run(ctx context.Context) error {
 // returns its stdout.
 func (r *runner) output(ctx context.Context) ([]byte, error) {
 	r.oneUse.assertNotStarted("get output")
+
+	if err := r.stdout.Close(); err != nil {
+		return nil, fmt.Errorf("closing previous stdout: %w", err)
+	}
 
 	var buf bytes.Buffer
 	r.applyOptions(WithStdout(&buf))


### PR DESCRIPTION
This is a rebased version of #62 targeted at #61: Fixes issues discovered doing a review of the latest stage-v2-clean state.

/cc @mhagger

<details><summary>Copilot Summary</summary><p>

This PR ports the v2 review-fix commits onto PR #61's `Pipe` / `runner` / `Config` branch:

- Cancel the derived `Pipe` context on pre-start failures and include the offending stage name in invalid stream requirement errors.
- Close an already-configured stdout closer before `Output()` replaces stdout with its capture buffer, adapted to `runner.output()` / `Pipeline.Output()`.
- Expose `WithStdinRequirement` and `WithStdoutRequirement` so `Function` stages can participate in stream requirement negotiation without reimplementing `Stage`.
- Document the known limitation for borrowed non-file stdin readers feeding command stages that can exit without draining stdin.

</p></details>
