### PR TITLE
Prevent command Kill races from panicking

### DIFF
--- a/pipe/command.go
+++ b/pipe/command.go
@@ -29,9 +29,12 @@ type commandStage struct {
 	wg     errgroup.Group
 	stderr bytes.Buffer
 
-	// If the context expired, and we attempted to kill the command,
-	// `ctx.Err()` is stored here.
+	// If we attempted to kill the command, the reason is stored here.
 	ctxErr atomic.Value
+}
+
+type commandKillError struct {
+	err error
 }
 
 var (
@@ -288,7 +291,7 @@ func (s *commandStage) filterCmdError(err error) error {
 		return err
 	}
 
-	ctxErr, ok := s.ctxErr.Load().(error)
+	ctxErr, ok := s.ctxErr.Load().(commandKillError)
 	if ok {
 		// If the process looks like it was killed by us, substitute
 		// `ctxErr` for the process's own exit error. Note that this
@@ -298,12 +301,18 @@ func (s *commandStage) filterCmdError(err error) error {
 		ps, ok := eErr.Sys().(syscall.WaitStatus)
 		if ok && ps.Signaled() &&
 			(ps.Signal() == syscall.SIGTERM || ps.Signal() == syscall.SIGKILL) {
-			return ctxErr
+			return ctxErr.err
 		}
 	}
 
 	eErr.Stderr = s.stderr.Bytes()
 	return eErr
+}
+
+func (s *commandStage) recordKillError(err error) {
+	if err != nil {
+		s.ctxErr.Store(commandKillError{err: err})
+	}
 }
 
 func (s *commandStage) Wait() error {

--- a/pipe/command.go
+++ b/pipe/command.go
@@ -29,8 +29,8 @@ type commandStage struct {
 	wg     errgroup.Group
 	stderr bytes.Buffer
 
-	// If we attempted to kill the command, the reason is stored here.
-	ctxErr atomic.Value
+	// If we attempted to kill the command, the first reason is stored here.
+	ctxErr atomic.Pointer[commandKillError]
 }
 
 type commandKillError struct {
@@ -291,8 +291,8 @@ func (s *commandStage) filterCmdError(err error) error {
 		return err
 	}
 
-	ctxErr, ok := s.ctxErr.Load().(commandKillError)
-	if ok {
+	ctxErr := s.ctxErr.Load()
+	if ctxErr != nil {
 		// If the process looks like it was killed by us, substitute
 		// `ctxErr` for the process's own exit error. Note that this
 		// doesn't do anything on Windows, where the `Signaled()`
@@ -311,7 +311,7 @@ func (s *commandStage) filterCmdError(err error) error {
 
 func (s *commandStage) recordKillError(err error) {
 	if err != nil {
-		s.ctxErr.Store(commandKillError{err: err})
+		s.ctxErr.CompareAndSwap(nil, &commandKillError{err: err})
 	}
 }
 

--- a/pipe/command_test.go
+++ b/pipe/command_test.go
@@ -86,15 +86,15 @@ func TestCopyEnvWithOverride(t *testing.T) {
 	}
 }
 
-func TestCommandStageRecordKillErrorAcceptsDifferentErrorTypes(t *testing.T) {
+func TestCommandStageRecordKillErrorAcceptsDifferentErrorTypesAndKeepsFirst(t *testing.T) {
 	errMemoryLimitExceeded := errors.New("memory limit exceeded")
 	var stage commandStage
 
-	stage.recordKillError(context.DeadlineExceeded)
 	stage.recordKillError(errMemoryLimitExceeded)
+	stage.recordKillError(context.DeadlineExceeded)
 
-	got, ok := stage.ctxErr.Load().(commandKillError)
-	if assert.True(t, ok, "expected ctxErr to store commandKillError") {
+	got := stage.ctxErr.Load()
+	if assert.NotNil(t, got, "expected ctxErr to store commandKillError") {
 		assert.ErrorIs(t, got.err, errMemoryLimitExceeded)
 	}
 }

--- a/pipe/command_test.go
+++ b/pipe/command_test.go
@@ -95,6 +95,6 @@ func TestCommandStageRecordKillErrorAcceptsDifferentErrorTypes(t *testing.T) {
 
 	got, ok := stage.ctxErr.Load().(commandKillError)
 	if assert.True(t, ok, "expected ctxErr to store commandKillError") {
-		assert.Error(t, errMemoryLimitExceeded, got.err)
+		assert.ErrorIs(t, got.err, errMemoryLimitExceeded)
 	}
 }

--- a/pipe/command_test.go
+++ b/pipe/command_test.go
@@ -1,6 +1,8 @@
 package pipe
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -81,5 +83,18 @@ func TestCopyEnvWithOverride(t *testing.T) {
 				copyEnvWithOverrides(ex.env, ex.overrides),
 			)
 		})
+	}
+}
+
+func TestCommandStageRecordKillErrorAcceptsDifferentErrorTypes(t *testing.T) {
+	errMemoryLimitExceeded := errors.New("memory limit exceeded")
+	var stage commandStage
+
+	stage.recordKillError(context.DeadlineExceeded)
+	stage.recordKillError(errMemoryLimitExceeded)
+
+	got, ok := stage.ctxErr.Load().(commandKillError)
+	if assert.True(t, ok, "expected ctxErr to store commandKillError") {
+		assert.Error(t, errMemoryLimitExceeded, got.err)
 	}
 }

--- a/pipe/command_unix.go
+++ b/pipe/command_unix.go
@@ -44,9 +44,8 @@ func (s *commandStage) Kill(err error) {
 	default:
 	}
 
-	// Record the `ctx.Err()`, which will be used as the error result
-	// for this stage.
-	s.ctxErr.Store(err)
+	// Record the kill reason, which will be used as the error result for this stage.
+	s.recordKillError(err)
 
 	// First try to kill using a relatively gentle signal so that
 	// the processes have a chance to clean up after themselves:

--- a/pipe/command_windows.go
+++ b/pipe/command_windows.go
@@ -21,9 +21,8 @@ func (s *commandStage) Kill(err error) {
 	default:
 	}
 
-	// Record the `ctx.Err()`, which will be used as the error result
-	// for this stage.
-	s.ctxErr.Store(err)
+	// Record the kill reason, which will be used as the error result for this stage.
+	s.recordKillError(err)
 
 	s.cmd.Process.Kill()
 }


### PR DESCRIPTION
A command stage can be killed from more than one goroutine. For example, a pipeline context can expire while another stage wrapper notices a resource limit and also calls Kill with its own error.

Those errors can have different concrete types. Storing them directly in atomic.Value makes the second store panic with "sync/atomic: store of inconsistently typed value into Value", crashing the process instead of returning a pipeline error to the caller.

So, use a small wrapper type to ensure that doesn't happen.